### PR TITLE
feature/san-tracking-anon-users

### DIFF
--- a/src/analytics/device.ts
+++ b/src/analytics/device.ts
@@ -1,0 +1,12 @@
+export function getDeviceId(): string | undefined {
+  if (!process.browser) return
+
+  const cookies = document.cookie.split('; ')
+
+  // NOTE: Searching for intercom's cookie with generated device id [@vanguard | 26 Jan, 2023]
+  const cookie = cookies.find((cookie) => cookie.includes('device-id'))
+
+  if (!cookie) return
+
+  return cookie.split('=')[1]
+}

--- a/src/api/analytics.ts
+++ b/src/api/analytics.ts
@@ -1,5 +1,5 @@
-import { getDeviceId } from '@/analytics/device'
 import { query, mutate } from '@/api'
+import { getDeviceId } from '@/analytics/device'
 
 export const CURRENT_USER_QUERY = `
   {


### PR DESCRIPTION
## Summary
Supporting tracking of anonymous users with `trackEvents` api by reusing intercom's device id cookie value