### PR TITLE
Make feedback text field optional

### DIFF
--- a/src/ui/Pricing/CancelSubscriptionDialog/FeedbackScreen.svelte
+++ b/src/ui/Pricing/CancelSubscriptionDialog/FeedbackScreen.svelte
@@ -44,10 +44,7 @@
     </div>
 
     <div>
-      <h3 class="txt-m mrg-m mrg--b row v-center nowrap" class:error={error && !feedback}>
-        Just one last thing*
-        <FieldRequired />
-      </h3>
+      <h3 class="txt-m mrg-m mrg--b row v-center nowrap" class:error>Just one last thing</h3>
       <textarea
         cols="30"
         rows="3"

--- a/src/ui/Pricing/CancelSubscriptionDialog/flow.ts
+++ b/src/ui/Pricing/CancelSubscriptionDialog/flow.ts
@@ -26,7 +26,9 @@ export function startCancellationFlow(
   feedback: string,
   closeDialog,
 ) {
-  track.event(Event.GiveFeedback, { feedback })
+  if (feedback) {
+    track.event(Event.GiveFeedback, { feedback })
+  }
 
   return mutateCancelSubscription(subscription.id)
     .then(() => {

--- a/src/ui/Pricing/CancelSubscriptionDialog/index.svelte
+++ b/src/ui/Pricing/CancelSubscriptionDialog/index.svelte
@@ -26,7 +26,7 @@
 
     if (!subscription) return
 
-    if (reasons.size === 0 || !feedback) {
+    if (reasons.size === 0) {
       error = true
       return
     }


### PR DESCRIPTION
1. Made feedback optional on Subscription cancellation dialog
(Requested by Anastasia G and Maxim B)

https://www.notion.so/santiment/Remove-required-text-field-from-Cancellation-361335b4b307449c97b9017ca2e60ba2

<img width="1156" alt="Снимок экрана 2023-01-30 в 14 36 40" src="https://user-images.githubusercontent.com/46782114/215467083-206cb43e-12a1-4083-b710-2857176a5185.png">
