### PR TITLE
Links listener and analytics event

### DIFF
--- a/src/analytics/events/general.ts
+++ b/src/analytics/events/general.ts
@@ -92,3 +92,6 @@ export const trackSideNavFeatures = ({
 
 export const trackSideNavRecents = ({ feature, url, source }) =>
   track('side_nav_recents', { feature, url, source, source_url: window.location.href })
+
+export const trackLink = ({ type, url, source, external = false }) =>
+  track('link', { type, url, source, external, source_url: window.location.href })

--- a/src/analytics/links.ts
+++ b/src/analytics/links.ts
@@ -1,0 +1,33 @@
+import { trackLink } from './events/general'
+
+export function startLinksListener() {
+  if (!process.browser) return
+
+  const root = document.documentElement
+
+  root.addEventListener('click', (e) => {
+    // Adapted from https://github.com/visionmedia/page.js
+    // MIT license https://github.com/visionmedia/page.js#license
+    const { button, metaKey, ctrlKey, shiftKey, altKey, defaultPrevented } = e
+    if (button) return
+    if (metaKey || ctrlKey || shiftKey || altKey) return
+    if (defaultPrevented) return
+
+    const target = e.target as null | HTMLElement
+    if (!target) return
+
+    const anchor = target.closest('a')
+    if (!anchor) return
+
+    const href = anchor.getAttribute('href') || ''
+    const isExternal = href.startsWith('http')
+    const { type, source } = anchor.dataset
+
+    if (isExternal) {
+      e.preventDefault()
+      window.open(href, '_blank')?.focus()
+    }
+
+    trackLink({ url: href, external: isExternal, type, source })
+  })
+}


### PR DESCRIPTION
## Summary
Global listener for `anchor` click events.
Extracting tracking information and sending analytics event.

## Notion
https://www.notion.so/santiment/Supporting-global-tracking-of-clicking-on-links-11dbf4b8f86f4e9b99d0be6ae4b421ad

## Example
```jsx
// index.js
startLinksListener()

// markup
<a herf="/profile" data-source="navbar" data-type="profile">Profile</a>
```