### PR TITLE
Feature/account dropdown rearrange

### DIFF
--- a/src/ui/AccountDropdown/LiteButton.svelte
+++ b/src/ui/AccountDropdown/LiteButton.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import Svg from '@/ui/Svg/svelte'
+
+  export let onOldVersionClick: () => void
+</script>
+
+<section>
+  <button class="btn-ghost btn--s fluid row v-center justify nowrap" on:click={onOldVersionClick}>
+    Back to classic version
+
+    <Svg id="right-arrow" w="10" h="5" />
+  </button>
+</section>
+
+<style>
+  section {
+    padding: 4px 8px;
+  }
+
+  button {
+    fill: var(--waterloo);
+  }
+</style>

--- a/src/ui/AccountDropdown/index.svelte
+++ b/src/ui/AccountDropdown/index.svelte
@@ -114,12 +114,6 @@
         >
       {/if}
 
-      <a
-        href="{SANBASE_ORIGIN}/pricing"
-        class="btn-ghost row justify v-center"
-        on:click={window.__onLinkClick}>Pricing</a
-      >
-
       <button
         class="btn-ghost row justify v-center"
         on:click={() => window.Intercom && window.Intercom('show')}

--- a/src/ui/AccountDropdown/index.svelte
+++ b/src/ui/AccountDropdown/index.svelte
@@ -11,6 +11,7 @@
   import { AccountStatusType } from '@/ui/AccountStatus.svelte'
   import UserInfo from './UserInfo.svelte'
   import VersionInfo from './VersionInfo.svelte'
+  import LiteButton from './LiteButton.svelte'
 
   export let currentUser
   export let onLogoutClick
@@ -20,6 +21,7 @@
   export let isAppUpdateAvailable = false
   export let version: string = '1.0.0'
   export let isShowingFollowers = true
+  export let onOldVersionClick: (() => void) | undefined = undefined
 
   const { ui$ } = getUI$Ctx()
   const { customer$ } = getCustomer$Ctx()
@@ -32,6 +34,7 @@
 
   $: customer = $customer$
   $: ({ isPro } = customer)
+  $: ({ isLiteVersion } = $ui$)
 </script>
 
 <Tooltip
@@ -62,6 +65,11 @@
       <hr />
       <VersionInfo {isAppUpdateAvailable} {version} />
       <hr />
+
+      {#if isLiteVersion && onOldVersionClick}
+        <LiteButton {onOldVersionClick} />
+        <hr />
+      {/if}
 
       <section>
         <a
@@ -99,6 +107,14 @@
           <Svg id="user" w="16" class="mrg-s mrg--r" />
           Log in
         </a>
+
+        {#if isLiteVersion && onOldVersionClick}
+          <anon-classic-section>
+            <hr />
+            <LiteButton {onOldVersionClick} />
+            <hr />
+          </anon-classic-section>
+        {/if}
       {/if}
 
       <button class="btn-ghost row justify v-center" on:click={ui$.toggleNightMode}>
@@ -160,6 +176,12 @@
 
   section {
     padding: 8px;
+  }
+
+  anon-classic-section {
+    display: block;
+    padding: 8px 0;
+    margin: 0 -8px;
   }
 
   .login {

--- a/stories/Core Components/AccountDropdown/index.svelte
+++ b/stories/Core Components/AccountDropdown/index.svelte
@@ -1,15 +1,22 @@
 <script lang="ts">
+  import { UI$$ } from '@/stores/ui'
   import AccountDropdown from '@/ui/AccountDropdown/index.svelte'
 
   export let currentUser: SAN.Author | null
 
+  const { ui$ } = UI$$({ isLiteVersion: true })
+
   function onLogoutClick() {
     console.log('LOG OUT')
+  }
+
+  function onOldVersionClick() {
+    $ui$.isLiteVersion = false
   }
 </script>
 
 <section class="row hv-center">
-  <AccountDropdown {currentUser} {onLogoutClick} />
+  <AccountDropdown {currentUser} {onLogoutClick} {onOldVersionClick} />
 </section>
 
 <style>


### PR DESCRIPTION
1. Remove `pricing` link from AccountDropdown
2. Add `Back to classic version` button to AccountDropdown

![image](https://github.com/santiment/san-webkit/assets/25119304/3f01e3c8-55c8-4945-a41b-b634c0ff0733)
![image](https://github.com/santiment/san-webkit/assets/25119304/0f6ab5f5-1f42-4436-9d4b-8d8d47774cde)
