### PR TITLE
Fix/night mode

### DIFF
--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -39,15 +39,17 @@ export function UI$$(defaultValue = {} as Record<string, any>) {
       ...ui$,
       toggleNightMode() {
         const { currentUser } = getSessionValue()
-        store.isNightMode = document.body.classList.toggle('night-mode')
+        const isNightMode = document.body.classList.toggle('night-mode')
 
         if (currentUser) {
-          mutate(TOGGLE_THEME_MUTATION(store.isNightMode)).catch(console.error)
+          mutate(TOGGLE_THEME_MUTATION(isNightMode)).catch(console.error)
         }
 
-        saveJson('ui', store)
-
-        ui$.set(store)
+        ui$.update((store) => {
+          const updated = { ...store, isNightMode }
+          saveJson('ui', updated)
+          return updated
+        })
       },
     },
   })

--- a/src/stores/ui.ts
+++ b/src/stores/ui.ts
@@ -16,7 +16,6 @@ const CTX = 'UI$$'
 
 export function UI$$(defaultValue = {} as Record<string, any>) {
   let store = { isNightMode: false, isLiteVersion: false, ...defaultValue }
-  const ui$ = writable(store)
 
   if (process.browser) {
     const { currentUser, theme } = getSessionValue()
@@ -32,6 +31,8 @@ export function UI$$(defaultValue = {} as Record<string, any>) {
 
     document.body.classList.toggle('night-mode', store.isNightMode || false)
   }
+
+  const ui$ = writable(store)
 
   return setContext(CTX, {
     ui$: {


### PR DESCRIPTION
## Summary
1. Fix desync between `isNightMode` in context and in dom. It caused incorrect `isNightMode` value in `AccountDropdown` and components uses `ui$` context to style itselves (like `Treemap`)
2. `toggleNightMode` used to set to `ui$` context `store` object which contained default `isLiteVersion`, so it could update app `isLiteVersion` state in unexpected way

## Screenshots
![image](https://github.com/santiment/san-webkit/assets/25119304/d1717245-98a5-4d5e-bbb5-8fa14f01572d)

![image](https://github.com/santiment/san-webkit/assets/25119304/6080334f-3a0c-43e7-b559-5c1d083c56c0)
