### PR TITLE
Feature/account settings pricing

### DIFF
--- a/.storybook/mock/user.ts
+++ b/.storybook/mock/user.ts
@@ -1,6 +1,7 @@
 import type { PromoCode } from '@/stores/user'
 
 import { getTodaysEnd } from '@/utils/dates'
+import { Plan, ProductId, checkIsBusinessPlan } from '@/utils/plans'
 
 export type CurrentUser = null | {
   /** @default 42 */
@@ -45,6 +46,9 @@ export type CurrentUser = null | {
     trial?: boolean
 
     /** @default undefined */
+    name?: Plan
+
+    /** @default undefined */
     trialDaysLeft?: number
 
     /** @default undefined */
@@ -85,10 +89,13 @@ export function mockUser(currentUser: CurrentUser) {
       trial = false,
       trialDaysLeft,
       cancelledInDays,
+      name: planName,
     } = plan
 
-    if (!pro && !proPlus) {
-      return document.write('Plan should have "pro" or "proPlus" value set to "true"')
+    if (!pro && !proPlus && !planName) {
+      return document.write(
+        'Plan should have "pro" or "proPlus" value set to "true" or have "name" property set',
+      )
     }
 
     if (!monthly && !yearly) {
@@ -115,7 +122,10 @@ export function mockUser(currentUser: CurrentUser) {
       currentPeriodEndDate.setDate(currentPeriodEndDate.getDate() + cancelledInDays)
     }
 
-    if (pro || proPlus) {
+    if (pro || proPlus || planName) {
+      const name = pro ? Plan.PRO : proPlus ? Plan.PRO_PLUS : planName
+      const id = name && checkIsBusinessPlan({ name }) ? ProductId.SANAPI : ProductId.SANBASE
+
       subscriptions[0] = {
         status: 'ACTIVE',
         trialEnd,
@@ -126,8 +136,8 @@ export function mockUser(currentUser: CurrentUser) {
           amount: 52900,
           id: '202',
           interval: yearly ? 'year' : 'month',
-          name: proPlus ? 'PRO_PLUS' : 'PRO',
-          product: { id: '2' },
+          name: name,
+          product: { id },
         },
       }
     }

--- a/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/Card.svelte
+++ b/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/Card.svelte
@@ -5,7 +5,7 @@
   export let title
   export let label = ''
   export let price
-  export let billing
+  export let billingTitle = ''
   export let discount
   export let badge
   export let link
@@ -15,6 +15,7 @@
   export let green = false
   export let orange = false
   export let yellow = false
+  export let blue = false
   export let disabled = false
   export let isChecked = false
   export let isActive = false
@@ -22,7 +23,14 @@
   export let onActionClick, onSubactionClick
 </script>
 
-<article class="relative fluid" class:green class:orange class:yellow class:wide={isFullAccess}>
+<article
+  class="relative column fluid"
+  class:green
+  class:orange
+  class:yellow
+  class:blue
+  class:wide={isFullAccess}
+>
   <h4 class="caption txt-m c-waterloo mrg-l mrg--b">{label}</h4>
   <h2 class="h4 txt-m mrg-xs mrg--b">{title}</h2>
 
@@ -39,18 +47,11 @@
     </div>
   {/if}
 
-  {#if billing && !shouldHideBillingInfo}
-    <div class="billing caption txt-m c-waterloo txt-right">
-      {billing}:
-      <h3 class="body-1 price c-black">
-        {price}{#if discount}/mo{/if}
-      </h3>
-    </div>
-  {/if}
-
-  <div class="actions row v-center mrg-xl mrg--t">
+  <div class="actions row v-center mrg-a mrg--t">
     <svelte:element
       this={link ? 'a' : 'button'}
+      role={link ? 'link' : 'button'}
+      tabindex="0"
       class="btn-1 v-center"
       class:disabled
       {...link}
@@ -65,6 +66,15 @@
 
     {#if subaction && onSubactionClick}
       <button class="btn-2 subaction mrg-m mrg--l" on:click={onSubactionClick}>{subaction}</button>
+    {/if}
+
+    {#if billingTitle && !shouldHideBillingInfo}
+      <div class="billing caption txt-m c-waterloo txt-right mrg-a mrg--l">
+        {billingTitle}
+        <h3 class="body-1 price c-black">
+          {price}{#if discount}/mo{/if}
+        </h3>
+      </div>
     {/if}
   </div>
 </article>
@@ -89,11 +99,22 @@
   .green {
     background: var(--green-light-1);
     --badge-color: var(--green);
+    --accent: var(--green);
   }
 
   .orange {
     background: var(--orange-light-1);
     --badge-color: var(--orange);
+    --accent: var(--orange);
+  }
+
+  .blue {
+    background: var(--blue-light-1);
+    --primary: var(--blue);
+    --primary-hover: var(--blue-hover);
+    --accent: var(--blue);
+    --badge: var(--white);
+    --badge-color: var(--blue);
   }
 
   .green,
@@ -141,6 +162,10 @@
     background: var(--green);
   }
 
+  .actions {
+    padding-top: 22px;
+  }
+
   .btn-1 {
     display: inline-flex;
     --bg: var(--primary, var(--green));
@@ -150,12 +175,6 @@
   .btn-2 {
     --bg: var(--white);
     --v-padding: 7px;
-  }
-
-  .billing {
-    position: absolute;
-    bottom: 16px;
-    right: 16px;
   }
 
   :global(.phone-xs),
@@ -169,7 +188,7 @@
     }
 
     .actions {
-      --margin: 16px;
+      padding-top: 16px;
       flex-direction: column;
       align-items: flex-start;
     }
@@ -188,7 +207,6 @@
     }
 
     .billing {
-      position: static;
       display: flex;
       align-items: center;
       margin-top: 12px;

--- a/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/FullAccessCard.svelte
+++ b/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/FullAccessCard.svelte
@@ -1,11 +1,13 @@
-<script>
+<script lang="ts">
   import { showIntercom } from '@/analytics/intercom'
   import Card from './Card.svelte'
+
+  export let currentPlanName: string
 </script>
 
 <Card
   yellow
-  title="Use Pro plan wisely"
+  title="Use {currentPlanName} plan wisely"
   label="You have full access!"
   action="Academy"
   subaction="Contact support"

--- a/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/PlanCard.svelte
+++ b/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/PlanCard.svelte
@@ -1,24 +1,17 @@
 <script lang="ts">
   import { SANBASE_ORIGIN } from '@/utils/links'
-  import {
-    checkIsYearlyPlan,
-    formatMonthlyPrice,
-    formatPrice,
-    getSavedAmount,
-    PlanName,
-  } from '@/utils/plans'
+  import { checkIsYearlyPlan, formatPrice, PlanName } from '@/utils/plans'
   import { showPaymentDialog } from '@/ui/PaymentDialog/index.svelte'
   import Card from './Card.svelte'
 
   export let plan: SAN.Plan
-  export let altPlan: SAN.Plan = plan
   export let discount: undefined | number
   export let action = 'Buy now'
   export let label, badge, badgeIcon
   export let isEligibleForTrial = false
   export let isTrial = false
   export let isUpgrade = false
-  export let shouldHideBillingInfo
+  export let shouldHideBillingInfo = false
   export let plans = [] as SAN.Plan[]
   export let onActionClick = () => {
     return showPaymentDialog({
@@ -32,22 +25,13 @@
 
   $: ({ name } = plan)
   $: annual = checkIsYearlyPlan(plan) ? ' / Annual' : ''
-  $: ({ billing, price } = getBillingPrice(plan, altPlan, annual))
+  $: ({ billing, price } = getBillingPrice(plan))
 
-  function getBillingPrice(plan, altPlan, annual) {
-    // if (plan === altPlan) {
+  function getBillingPrice(plan: SAN.Plan) {
     return {
       price: formatPrice(plan),
       billing: `Billed ${plan.interval}ly`,
     }
-    // }
-
-    // return {
-    //   price: formatMonthlyPrice(plan, discount),
-    //   billing: annual
-    //     ? `You save ${getSavedAmount(plan, altPlan, discount)} this year`
-    //     : 'Billed monthly',
-    // }
   }
 </script>
 

--- a/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/PlanCard.svelte
+++ b/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/PlanCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { SANBASE_ORIGIN } from '@/utils/links'
-  import { checkIsYearlyPlan, formatPrice, PlanName } from '@/utils/plans'
+  import { formatPrice, Plan, PlanName } from '@/utils/plans'
   import { showPaymentDialog } from '@/ui/PaymentDialog/index.svelte'
   import Card from './Card.svelte'
 
@@ -13,6 +13,7 @@
   export let isUpgrade = false
   export let shouldHideBillingInfo = false
   export let plans = [] as SAN.Plan[]
+  export let description = ''
   export let onActionClick = () => {
     return showPaymentDialog({
       plans,
@@ -24,20 +25,25 @@
   }
 
   $: ({ name } = plan)
-  $: annual = checkIsYearlyPlan(plan) ? ' / Annual' : ''
   $: ({ billing, price } = getBillingPrice(plan))
 
   function getBillingPrice(plan: SAN.Plan) {
+    if (plan.name === Plan.CUSTOM)
+      return {
+        price: 'Custom',
+        billing: 'Based on your needs',
+      }
+
     return {
       price: formatPrice(plan),
-      billing: `Billed ${plan.interval}ly`,
+      billing: `Billed ${plan.interval}ly:`,
     }
   }
 </script>
 
 <Card
   {...$$restProps}
-  {billing}
+  billingTitle={billing}
   {price}
   {discount}
   {shouldHideBillingInfo}
@@ -50,23 +56,19 @@
     ? 'Upgrade'
     : action}
   disabled={action === 'Default plan'}
-  title={PlanName[name] + (isTrial ? ' Trial' : '') + annual}
+  title={PlanName[name] + (isTrial ? ' Trial' : '')}
   label={discount ? 'Special offer' : label}
   badge={discount ? `${discount}% Off` : badge}
   badgeIcon={discount ? null : badgeIcon}
 >
   <slot>
     <p>
-      {#if badge === 'Popular'}
-        Get access to advanced crypto metrics, market insights and more!
-      {:else}
-        Advanced plan with complete access to analytics, backtesting framework.
-      {/if}
+      {description}
 
       Check all plans
-      <a href="{SANBASE_ORIGIN}/pricing" class="link-pointer" on:click={window.__onLinkClick}
-        >here!</a
-      >
+      <a href="{SANBASE_ORIGIN}/pricing" class="link-pointer" on:click={window.__onLinkClick}>
+        here!
+      </a>
     </p>
   </slot>
 </Card>

--- a/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/PlanCard.svelte
+++ b/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/PlanCard.svelte
@@ -15,6 +15,11 @@
   export let plans = [] as SAN.Plan[]
   export let description = ''
   export let onActionClick = () => {
+    if (plan.name === Plan.CUSTOM) {
+      window.open('https://calendly.com/santiment-team/santiment-enterprise-plan-enquiry', '_blank')
+      return
+    }
+
     return showPaymentDialog({
       plans,
       plan: plan.name,
@@ -48,7 +53,9 @@
   {discount}
   {shouldHideBillingInfo}
   {onActionClick}
-  action={discount
+  action={plan.name === Plan.CUSTOM
+    ? 'Let’s talk!'
+    : discount
     ? `Pay now ${discount}% Off`
     : isEligibleForTrial
     ? 'Start 14-day Free Trial'

--- a/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/PlanSuggestions.svelte
+++ b/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/PlanSuggestions.svelte
@@ -6,7 +6,7 @@
 
   export let suggestions: PlanSuggestion[]
   export let plans: SAN.Plan[]
-  export let isEligibleForTrial: boolean
+  export let isEligibleForTrial = false
 
   const EMPTY_SUGGESTION: Suggestion = {
     label: '',

--- a/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/PlanSuggestions.svelte
+++ b/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/PlanSuggestions.svelte
@@ -1,0 +1,50 @@
+<script lang="ts">
+  import type { PlanSuggestion, Suggestion } from './suggestions'
+
+  import { getAlternativePlan } from '@/utils/plans'
+  import PlanCard from './PlanCard.svelte'
+
+  export let suggestions: PlanSuggestion[]
+  export let plans: SAN.Plan[]
+  export let isEligibleForTrial: boolean
+
+  const EMPTY_SUGGESTION: Suggestion = {
+    label: '',
+    badge: '',
+    badgeIcon: { id: '', w: 0 },
+    description: '',
+  }
+
+  $: suggestedPlans = getPlanSuggestions(plans, suggestions)
+
+  function getPlanSuggestions(plans: SAN.Plan[], suggestions: PlanSuggestion[]) {
+    if (!suggestions.length) return []
+
+    return plans.filter((plan) => {
+      const isSameBilling = plan.interval === suggestions[0].billing
+      if (suggestions[0].discount) {
+        return isSameBilling
+      }
+
+      return suggestions.some((suggestion) => !!suggestion[plan.name]) && isSameBilling
+    })
+  }
+</script>
+
+{#each suggestedPlans as suggestion, index}
+  {@const currentSuggestion = suggestions[index] || {}}
+  {@const altPlan = getAlternativePlan(suggestion, plans)}
+  {@const planOptions = altPlan ? [suggestion, altPlan] : [suggestion]}
+  {@const planInfo = currentSuggestion[suggestion.name] ?? EMPTY_SUGGESTION}
+
+  <PlanCard
+    {...planInfo}
+    {isEligibleForTrial}
+    plans={planOptions}
+    discount={currentSuggestion.discount}
+    isUpgrade={currentSuggestion.isUpgrade}
+    plan={suggestion}
+  />
+{:else}
+  <slot />
+{/each}

--- a/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/suggestions.ts
+++ b/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/suggestions.ts
@@ -1,41 +1,122 @@
-import { Billing, Plan } from '@/utils/plans'
+import type { ComponentProps } from 'svelte'
+import type Svg from '@/ui/Svg/svelte'
 
-export const PRO_SUGGESTION = {
+import {
+  BUSINESS_PLANS,
+  Billing,
+  Plan,
+  checkIsBusinessPlan,
+  checkIsIndividualPlan,
+} from '@/utils/plans'
+
+type Suggestion = {
+  label: string
+  badge: string
+  badgeIcon: { id: ComponentProps<Svg>['id']; w: number }
+  green?: boolean
+  orange?: boolean
+}
+
+const PRO_SUGGESTION = {
   label: 'Suggested for you',
   badge: 'Popular',
   badgeIcon: { id: 'star-filled', w: 16 },
   green: true,
-}
+} satisfies Suggestion
 
-export const PRO_PLUS_SUGGESTION = {
+const MAX_SUGGESTION = {
   label: 'Next level',
   badge: 'Advanced',
   badgeIcon: { id: 'rocket-filled', w: 17 },
   orange: true,
+} satisfies Suggestion
+
+const BUSINESS_PRO_SUGGESTION = {
+  label: '💼 For Business',
+  badge: 'Starter',
+  badgeIcon: { id: 'star-filled', w: 16 },
+} satisfies Suggestion
+
+const BUSINESS_MAX_SUGGESTION = {
+  label: '💼 For Business',
+  badge: 'Advanced',
+  badgeIcon: { id: 'rocket-filled', w: 17 },
+} satisfies Suggestion
+
+const ENTERPRISE_SUGGESTION = {
+  label: '💼 For Business',
+  badge: 'Custom',
+  badgeIcon: { id: 'fire-filled', w: 16 },
+} satisfies Suggestion
+
+const BUSINESS_SUGGESTIONS = {
+  [Plan.BUSINESS_PRO]: BUSINESS_PRO_SUGGESTION,
+  [Plan.BUSINESS_MAX]: BUSINESS_MAX_SUGGESTION,
+  [Plan.CUSTOM]: ENTERPRISE_SUGGESTION,
 }
 
-export function getSuggestions(
-  userPlan: null | SAN.Plan,
+export type PlanSuggestion = {
+  billing?: string
+  discount?: number
+  isUpgrade?: boolean
+  fullAccess?: boolean
+} & {
+  [key in Plan]?: Suggestion
+}
+
+export type UserPlan = Exclude<SAN.Customer['subscription'], null | undefined>['plan']
+
+export function getBusinessSuggestions(userPlan: UserPlan | null): PlanSuggestion[] {
+  const suggestion = {
+    billing: userPlan?.interval ?? Billing.MONTH,
+  }
+
+  const allBusinessSuggestions = Object.entries(BUSINESS_SUGGESTIONS).map(
+    ([plan, planSuggestion]) => ({
+      ...suggestion,
+      [plan]: planSuggestion,
+    }),
+  )
+
+  if (!userPlan || checkIsIndividualPlan(userPlan)) return allBusinessSuggestions
+
+  if (userPlan.name === Plan.BUSINESS_PRO) {
+    return allBusinessSuggestions.slice(1)
+  }
+
+  const planIndex = Array.from(BUSINESS_PLANS).indexOf(userPlan.name as Plan)
+  if (planIndex === -1) return allBusinessSuggestions
+  if (planIndex >= BUSINESS_PLANS.size - 1) return []
+
+  return allBusinessSuggestions.slice(planIndex + 1)
+}
+
+export function getIndividualSuggestions(
+  userPlan: null | UserPlan,
   annualDiscount: SAN.Customer['annualDiscount'],
-) {
-  const suggestions = [] as any
+): PlanSuggestion[] {
+  const suggestions: PlanSuggestion[] = []
+
+  if (userPlan && checkIsBusinessPlan(userPlan)) {
+    return []
+  }
 
   if (annualDiscount.isEligible) {
     const suggestion = {
-      discount: annualDiscount.percent,
+      discount: annualDiscount.percent || 0,
       billing: Billing.YEAR,
-    } as any
+    }
 
     suggestions.push({ ...suggestion, [Plan.PRO]: PRO_SUGGESTION })
 
     if (userPlan?.name === Plan.PRO) {
-      suggestions.push({ ...suggestion, [Plan.PRO_PLUS]: PRO_PLUS_SUGGESTION })
+      suggestions.push({ ...suggestion, [Plan.MAX]: MAX_SUGGESTION })
     }
 
     return suggestions
   }
 
-  if (userPlan?.name === Plan.PRO_PLUS) {
+  if (userPlan?.name === Plan.PRO_PLUS || userPlan?.name === Plan.MAX) {
     return [{ fullAccess: true }]
   }
 
@@ -52,7 +133,7 @@ export function getSuggestions(
 
   suggestions.push({
     ...suggestion,
-    [Plan.PRO_PLUS]: PRO_PLUS_SUGGESTION,
+    [Plan.MAX]: MAX_SUGGESTION,
     isUpgrade: userPlan?.name === Plan.PRO,
   })
 

--- a/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/suggestions.ts
+++ b/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/suggestions.ts
@@ -13,14 +13,17 @@ type Suggestion = {
   label: string
   badge: string
   badgeIcon: { id: ComponentProps<Svg>['id']; w: number }
+  description: string
   green?: boolean
   orange?: boolean
+  blue?: boolean
 }
 
 const PRO_SUGGESTION = {
   label: 'Suggested for you',
   badge: 'Popular',
   badgeIcon: { id: 'star-filled', w: 16 },
+  description: 'Get access to advanced crypto metrics, market insights and more!',
   green: true,
 } satisfies Suggestion
 
@@ -28,6 +31,7 @@ const MAX_SUGGESTION = {
   label: 'Next level',
   badge: 'Advanced',
   badgeIcon: { id: 'rocket-filled', w: 17 },
+  description: 'Advanced plan with complete access to analytics, backtesting framework.',
   orange: true,
 } satisfies Suggestion
 
@@ -35,18 +39,24 @@ const BUSINESS_PRO_SUGGESTION = {
   label: '💼 For Business',
   badge: 'Starter',
   badgeIcon: { id: 'star-filled', w: 16 },
+  description: 'The starting point for your business with real-time API calls.',
+  blue: true,
 } satisfies Suggestion
 
 const BUSINESS_MAX_SUGGESTION = {
   label: '💼 For Business',
   badge: 'Advanced',
   badgeIcon: { id: 'rocket-filled', w: 17 },
+  description: 'Business plan for extensive research and strategy testing.',
+  blue: true,
 } satisfies Suggestion
 
 const ENTERPRISE_SUGGESTION = {
   label: '💼 For Business',
   badge: 'Custom',
   badgeIcon: { id: 'fire-filled', w: 16 },
+  description: 'Everything your business needs as a tailored solution.',
+  blue: true,
 } satisfies Suggestion
 
 const BUSINESS_SUGGESTIONS = {

--- a/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/suggestions.ts
+++ b/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/suggestions.ts
@@ -9,7 +9,7 @@ import {
   checkIsIndividualPlan,
 } from '@/utils/plans'
 
-type Suggestion = {
+export type Suggestion = {
   label: string
   badge: string
   badgeIcon: { id: ComponentProps<Svg>['id']; w: number }

--- a/src/ui/Pricing/SubscriptionSettings/index.svelte
+++ b/src/ui/Pricing/SubscriptionSettings/index.svelte
@@ -69,7 +69,11 @@
       individualPlans = pppSettings.plans
     }
 
-    plans = individualPlans.concat(businessPlans)
+    plans = individualPlans
+      .concat(businessPlans)
+      .sort((a, b) =>
+        a.name === Plan.CUSTOM ? 1 : b.name === Plan.CUSTOM ? -1 : a.amount - b.amount,
+      )
   }
 
   function getPlanSuggestions(plans: SAN.Plan[], suggestions: PlanSuggestion[]) {
@@ -104,7 +108,8 @@
         {@const planInfo = currentSuggestion[suggestion.name] ?? {
           label: '',
           badge: '',
-          badgeIcon: {},
+          badgeIcon: { id: '', w: 0 },
+          description: '',
         }}
 
         <PlanCard

--- a/src/ui/Pricing/SubscriptionSettings/index.svelte
+++ b/src/ui/Pricing/SubscriptionSettings/index.svelte
@@ -90,7 +90,7 @@
     </plans-section>
 
     <plans-section>
-      <PlanSuggestions suggestions={businessSuggestions} {plans} {isEligibleForTrial} />
+      <PlanSuggestions suggestions={businessSuggestions} {plans} />
     </plans-section>
   </Setting>
 

--- a/src/ui/Pricing/SubscriptionSettings/index.svelte
+++ b/src/ui/Pricing/SubscriptionSettings/index.svelte
@@ -7,7 +7,7 @@
   import { getBusinessPlans, getIndividualPlans, queryPlans, queryPppSettings } from '@/api/plans'
   import { getCustomer$Ctx } from '@/stores/customer'
   import { paymentCard$ } from '@/stores/paymentCard'
-  import { Billing, Plan, ProductId } from '@/utils/plans'
+  import { Billing, Plan, ProductId, getAlternativePlan } from '@/utils/plans'
   import { checkIsActiveSubscription } from '@/utils/subscription'
   import Setting from './Setting.svelte'
   import PlanCard from './SubscriptionCard/PlanCard.svelte'
@@ -105,6 +105,8 @@
 
       {#each suggestedIndividualPlans as suggestion, index}
         {@const currentSuggestion = individualSuggestions[index] || {}}
+        {@const altPlan = getAlternativePlan(suggestion, plans)}
+        {@const planOptions = altPlan ? [suggestion, altPlan] : [suggestion]}
         {@const planInfo = currentSuggestion[suggestion.name] ?? {
           label: '',
           badge: '',
@@ -115,7 +117,7 @@
         <PlanCard
           {...planInfo}
           {isEligibleForTrial}
-          {plans}
+          plans={planOptions}
           discount={currentSuggestion.discount}
           isUpgrade={currentSuggestion.isUpgrade}
           suggestionsCount={suggestedIndividualPlans.length}
@@ -129,6 +131,8 @@
     <plans-section>
       {#each suggestedBusinessPlans as suggestion, index}
         {@const currentSuggestion = businessSuggestions[index] || {}}
+        {@const altPlan = getAlternativePlan(suggestion, plans)}
+        {@const planOptions = altPlan ? [suggestion, altPlan] : [suggestion]}
         {@const planInfo = currentSuggestion[suggestion.name] ?? {
           label: '',
           badge: '',
@@ -138,7 +142,7 @@
         <PlanCard
           {...planInfo}
           {isEligibleForTrial}
-          {plans}
+          plans={planOptions}
           discount={currentSuggestion.discount}
           isUpgrade={currentSuggestion.isUpgrade}
           suggestionsCount={suggestedIndividualPlans.length}

--- a/src/utils/plans.ts
+++ b/src/utils/plans.ts
@@ -59,10 +59,11 @@ export enum PlanType {
   BUSINESS = 'business',
 }
 
-export const checkIsIndividualPlan = ({ name }: SAN.Plan) => INDIVIDUAL_PLANS.has(name)
-export const checkIsBusinessPlan = ({ name }: SAN.Plan) => BUSINESS_PLANS.has(name)
+export const checkIsIndividualPlan = ({ name }: { name: string }) =>
+  INDIVIDUAL_PLANS.has(name as Plan)
+export const checkIsBusinessPlan = ({ name }: { name: string }) => BUSINESS_PLANS.has(name as Plan)
 
-export const checkIsPlanWithPrice = ({ amount }: SAN.Plan) => amount > 0
+export const checkIsPlanWithPrice = ({ amount }: Pick<SAN.Plan, 'amount'>) => amount > 0
 
 export const checkIsYearlyPlan = ({ interval }: Pick<SAN.Plan, 'interval'>) =>
   interval === Billing.YEAR
@@ -97,7 +98,7 @@ export const onlyProLikePlans = ({ name }: SAN.Plan) => name.includes(Plan.PRO)
 export const onlyProAndFreeLikePlans = ({ name }: SAN.Plan) =>
   name.includes(Plan.PRO) || name.includes(Plan.FREE)
 
-export function getAlternativePlan(plan: SAN.Plan, plans: SAN.Plan[]) {
+export function getAlternativePlan(plan: { name?: string; interval?: string }, plans: SAN.Plan[]) {
   return plans.find(({ name, interval }) => name === plan.name && interval !== plan.interval)
 }
 

--- a/stories/Subscription/SubscriptionSettings/index.stories.ts
+++ b/stories/Subscription/SubscriptionSettings/index.stories.ts
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from '@storybook/svelte'
 import Component from '@/ui/Pricing/SubscriptionSettings/index.svelte'
 import { mockPlans } from '../Payment Dialog/plans'
 import { pppMock } from './mock'
+import { Plan } from '@/utils/plans'
 
 const meta = {
   // title: 'Design System/Icons',
@@ -134,6 +135,38 @@ export const ProPlusYearNoCard: Story = {
       currentUser: {
         plan: {
           proPlus: true,
+          yearly: true,
+        },
+      },
+    }),
+  },
+}
+
+export const MaxYearNoCard: Story = {
+  parameters: {
+    mockApi: () => ({
+      ...mockPlans,
+      ...pppMock,
+      savedCard: false,
+      currentUser: {
+        plan: {
+          name: Plan.MAX,
+          yearly: true,
+        },
+      },
+    }),
+  },
+}
+
+export const BusinessProYearNoCard: Story = {
+  parameters: {
+    mockApi: () => ({
+      ...mockPlans,
+      ...pppMock,
+      savedCard: false,
+      currentUser: {
+        plan: {
+          name: Plan.BUSINESS_PRO,
           yearly: true,
         },
       },

--- a/stories/Subscription/SubscriptionSettings/index.stories.ts
+++ b/stories/Subscription/SubscriptionSettings/index.stories.ts
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/svelte'
 
 import Component from '@/ui/Pricing/SubscriptionSettings/index.svelte'
+import { mockPlans } from '../Payment Dialog/plans'
+import { pppMock } from './mock'
 
 const meta = {
   // title: 'Design System/Icons',
@@ -21,6 +23,8 @@ export default meta
 export const FreeNoCard: Story = {
   parameters: {
     mockApi: () => ({
+      ...mockPlans,
+      ...pppMock,
       savedCard: false,
       currentUser: {},
     }),
@@ -30,6 +34,8 @@ export const FreeNoCard: Story = {
 export const FreeWithCard: Story = {
   parameters: {
     mockApi: () => ({
+      ...mockPlans,
+      ...pppMock,
       savedCard: true,
       currentUser: {},
     }),
@@ -39,6 +45,8 @@ export const FreeWithCard: Story = {
 export const ProTrialNoCard: Story = {
   parameters: {
     mockApi: () => ({
+      ...mockPlans,
+      ...pppMock,
       savedCard: false,
       currentUser: {
         plan: {
@@ -54,6 +62,8 @@ export const ProTrialNoCard: Story = {
 export const ProTrialCanceledNoCard: Story = {
   parameters: {
     mockApi: () => ({
+      ...mockPlans,
+      ...pppMock,
       savedCard: false,
       currentUser: {
         plan: {
@@ -70,6 +80,8 @@ export const ProTrialCanceledNoCard: Story = {
 export const ProMonthNoCard: Story = {
   parameters: {
     mockApi: () => ({
+      ...mockPlans,
+      ...pppMock,
       savedCard: false,
       currentUser: {
         plan: {
@@ -84,6 +96,8 @@ export const ProMonthNoCard: Story = {
 export const ProYearNoCard: Story = {
   parameters: {
     mockApi: () => ({
+      ...mockPlans,
+      ...pppMock,
       savedCard: false,
       currentUser: {
         plan: {
@@ -98,6 +112,8 @@ export const ProYearNoCard: Story = {
 export const ProPlusMonthNoCard: Story = {
   parameters: {
     mockApi: () => ({
+      ...mockPlans,
+      ...pppMock,
       savedCard: false,
       currentUser: {
         plan: {
@@ -112,6 +128,8 @@ export const ProPlusMonthNoCard: Story = {
 export const ProPlusYearNoCard: Story = {
   parameters: {
     mockApi: () => ({
+      ...mockPlans,
+      ...pppMock,
       savedCard: false,
       currentUser: {
         plan: {

--- a/stories/Subscription/SubscriptionSettings/mock.ts
+++ b/stories/Subscription/SubscriptionSettings/mock.ts
@@ -1,0 +1,8 @@
+export const pppMock = {
+  'query pppSettings': {
+    country: null,
+    isEligibleForPpp: false,
+    percentOff: null,
+    plans: null,
+  },
+}


### PR DESCRIPTION
## Summary

Add business plans cards to SubscriptionSettings.
If user has current individual plan active, all business are shown
If user has current business plan, only "greater" plans are shown

## Notion card
https://www.notion.so/santiment/Redesign-and-new-flow-for-the-pricing-page-4c926fa05a7e41b690e3bfcd3d5fc66b?pvs=4#f5d89d53af80425db8fb4fc31645f03e

## Screenshots
![image](https://github.com/santiment/san-webkit/assets/25119304/f2950e70-c2d8-46b7-b0e5-640ace54dacf)
