### PR TITLE
fix(pricing) Add product id to plan identification logic to prevent ambiguity for plans with same name

### DIFF
--- a/.storybook/mock/user.ts
+++ b/.storybook/mock/user.ts
@@ -1,7 +1,7 @@
 import type { PromoCode } from '@/stores/user'
 
 import { getTodaysEnd } from '@/utils/dates'
-import { Plan, ProductId, checkIsBusinessPlan } from '@/utils/plans'
+import { Plan, ProductId } from '@/utils/plans'
 
 export type CurrentUser = null | {
   /** @default 42 */
@@ -53,6 +53,9 @@ export type CurrentUser = null | {
 
     /** @default undefined */
     cancelledInDays?: number
+
+    /** @default ProductId.SANBASE */
+    productId?: ProductId
   }
 
   promoCodes?: PromoCode[]
@@ -90,6 +93,7 @@ export function mockUser(currentUser: CurrentUser) {
       trialDaysLeft,
       cancelledInDays,
       name: planName,
+      productId = ProductId.SANBASE,
     } = plan
 
     if (!pro && !proPlus && !planName) {
@@ -124,7 +128,6 @@ export function mockUser(currentUser: CurrentUser) {
 
     if (pro || proPlus || planName) {
       const name = pro ? Plan.PRO : proPlus ? Plan.PRO_PLUS : planName
-      const id = name && checkIsBusinessPlan({ name }) ? ProductId.SANAPI : ProductId.SANBASE
 
       subscriptions[0] = {
         status: 'ACTIVE',
@@ -137,7 +140,7 @@ export function mockUser(currentUser: CurrentUser) {
           id: '202',
           interval: yearly ? 'year' : 'month',
           name: name,
-          product: { id },
+          product: { id: productId },
         },
       }
     }

--- a/src/analytics/events/payment.ts
+++ b/src/analytics/events/payment.ts
@@ -16,9 +16,9 @@ export const trackPaymentFormOpened = ({
   source,
   currency = CurrencyType.USD,
 }: {
-  plan: string
-  planId: number
-  amount: number
+  plan: string | undefined
+  planId: number | undefined
+  amount: number | undefined
   billing: SAN.PlanInterval
   currency?: CurrencyType
   source: string

--- a/src/api/plans.ts
+++ b/src/api/plans.ts
@@ -29,7 +29,11 @@ type Query = SAN.API.Query<'productsWithPlans', ProductPlans[]>
 
 type ProductGetter = (products: ProductPlans[]) => undefined | ProductPlans['plans']
 
-const accessor = ({ productsWithPlans }: Query) => productsWithPlans
+const accessor = ({ productsWithPlans }: Query) =>
+  productsWithPlans.map((product) => ({
+    ...product,
+    plans: product.plans.map((plan) => ({ ...plan, product: { id: +product.id } })),
+  }))
 export const queryPlans = () => query<Query>(PLANS_QUERY).then(accessor)
 
 export const queryProductPlans = (
@@ -157,6 +161,9 @@ export const queryPppSettings = () =>
       interval
       amount
       isDeprecated
+      product {
+        id
+      }
     }
   }
 }`).then((data) => {

--- a/src/stores/customer.ts
+++ b/src/stores/customer.ts
@@ -9,7 +9,7 @@ import {
   normalizeAnnualDiscount,
   Status,
 } from '@/utils/subscription'
-import { Plan, PlanName, checkIsBusinessPlan } from '@/utils/plans'
+import { Plan, getPlanDisplayName, checkIsBusinessPlan } from '@/utils/plans'
 import { QueryStore, setSessionValue } from './utils'
 import { BROWSER } from 'esm-env'
 
@@ -129,7 +129,7 @@ function getCustomerSubscriptionData(subscription: undefined | null | any) {
 
     isTrial: trialDaysLeft > 0 && status === Status.TRIALING,
     trialDaysLeft,
-    planName: PlanName[planName] || planName,
+    planName: getPlanDisplayName(plan),
     isCanceled: !!cancelAtPeriodEnd,
   }
 }

--- a/src/types/plan.d.ts
+++ b/src/types/plan.d.ts
@@ -3,10 +3,11 @@ declare namespace SAN {
 
   type Plan = {
     id: string | number
-    name: import('../utils/plans').Plan
+    name: string
     interval: PlanInterval
     amount: number
     isDeprecated: boolean
+    product: Product
   }
 
   type Product = {

--- a/src/ui/PaymentDialog/PlanSelector.svelte
+++ b/src/ui/PaymentDialog/PlanSelector.svelte
@@ -3,7 +3,7 @@
   import Svg from '@/ui/Svg/svelte'
   import Tooltip from '@/ui/Tooltip'
   import {
-    PlanName,
+    getPlanDisplayName,
     checkIsYearlyPlan,
     formatMonthlyPrice,
     Billing,
@@ -75,7 +75,7 @@
             class:active={plan === option}
             on:click={() => select(option)}
           >
-            {isSinglePlan ? 'Bill' : PlanName[option.name]}
+            {isSinglePlan ? 'Bill' : getPlanDisplayName(option)}
             {option.interval === Billing.YEAR ? 'annual' : 'montly'} -
             <span class="txt-b">{formatMonthlyPrice(option)}/mo</span>
 

--- a/src/ui/PaymentDialog/utils.ts
+++ b/src/ui/PaymentDialog/utils.ts
@@ -1,7 +1,7 @@
 import { track, Tracker } from '@/analytics'
 import { trackTwitterPurchaseEvent, TwitterTrackActions } from '@/analytics/twitter'
 import { mutateSubscribe } from '@/api/plans'
-import { PlanName } from '@/utils/plans'
+import { getPlanDisplayName } from '@/utils/plans'
 import { notifications$ } from '@/ui/Notifications'
 import { paymentCard$ } from '@/stores/paymentCard'
 import {
@@ -117,8 +117,8 @@ export function buyPlan(
 
 export function onPaymentSuccess(data, source, customer$: SAN.CustomerStore, method?: string) {
   const { plan } = data
-  const { name, amount } = plan
-  const title = PlanName[name] || name
+  const { amount } = plan
+  const title = getPlanDisplayName(plan)
 
   trackTwitterPurchaseEvent()
 

--- a/src/ui/Pricing/Comparison/Plan.svelte
+++ b/src/ui/Pricing/Comparison/Plan.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { formatMonthlyPrice, Plan, PlanName } from '@/utils/plans'
+  import { formatMonthlyPrice, Plan, getPlanDisplayName } from '@/utils/plans'
   import PlanButton from '../PlanButton.svelte'
 
   export let plan: SAN.Plan
@@ -12,7 +12,7 @@
 
 <div class="fluid">
   <h3 class="row v-center">
-    <span class="h4 txt-m">{PlanName[name]}</span>
+    <span class="h4 txt-m">{getPlanDisplayName(plan)}</span>
 
     {#if discount && !isFreePlan}<span class="discount mrg-m mrg--l">50% Off</span>{/if}
 

--- a/src/ui/Pricing/Plan.svelte
+++ b/src/ui/Pricing/Plan.svelte
@@ -6,7 +6,7 @@
     formatPrice,
     checkIsBusinessPlan,
     Plan,
-    PlanName,
+    getPlanDisplayName,
   } from '@/utils/plans'
   import { checkIsTrialSubscription } from '@/utils/subscription'
   import PlanButton from './PlanButton.svelte'
@@ -43,7 +43,7 @@
 </script>
 
 <div class="plan txt-center relative {className}" class:isBusiness class:free={isFreePlan}>
-  <div class="name h4 txt-m c-accent">{PlanName[name]}</div>
+  <div class="name h4 txt-m c-accent">{getPlanDisplayName(plan)}</div>
 
   {#if isTrialPlan}<div class="trial label">Your trial plan</div>{/if}
 

--- a/src/ui/Pricing/PlanChangeDialog.svelte
+++ b/src/ui/Pricing/PlanChangeDialog.svelte
@@ -10,7 +10,7 @@
   import { DialogLock } from '@/ui/Dialog/dialogs'
   import Svg from '@/ui/Svg/svelte'
   import { getCustomer$Ctx } from '@/stores/customer'
-  import { Billing, formatPrice, PlanName } from '@/utils/plans'
+  import { Billing, formatPrice, getPlanDisplayName } from '@/utils/plans'
   import { getDateFormats } from '@/utils/dates'
   import { mutateUpdateSubscription } from '@/api/subscription'
   import { onPlanChangeError, onPlanChangeSuccess } from './utils'
@@ -26,12 +26,12 @@
   const { customer$ } = getCustomer$Ctx()
 
   const subscription = $customer$.subscription as SAN.Subscription
-  const newName = PlanName[plan.name] || plan.name
+  const newName = getPlanDisplayName(plan)
   const isNewBillingMonthly = plan.interval === Billing.MONTH
   const newBilling = isNewBillingMonthly ? 'Monthly' : 'Annual'
 
   const { currentPeriodEnd = Date.now(), plan: currentPlan } = subscription
-  const currentPlanName = PlanName[currentPlan.name] || currentPlan.name
+  const currentPlanName = getPlanDisplayName(currentPlan)
 
   function formatDate() {
     const { MMMM, DD, YYYY } = getDateFormats(new Date(currentPeriodEnd))

--- a/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/PlanCard.svelte
+++ b/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/PlanCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { SANBASE_ORIGIN } from '@/utils/links'
-  import { formatPrice, Plan, PlanName } from '@/utils/plans'
+  import { formatPrice, Plan, getPlanDisplayName } from '@/utils/plans'
   import { showPaymentDialog } from '@/ui/PaymentDialog/index.svelte'
   import Card from './Card.svelte'
 
@@ -29,7 +29,7 @@
     })
   }
 
-  $: ({ name } = plan)
+  $: displayName = getPlanDisplayName(plan)
   $: ({ billing, price } = getBillingPrice(plan))
 
   function getBillingPrice(plan: SAN.Plan) {
@@ -63,7 +63,7 @@
     ? 'Upgrade'
     : action}
   disabled={action === 'Default plan'}
-  title={PlanName[name] + (isTrial ? ' Trial' : '')}
+  title={displayName + (isTrial ? ' Trial' : '')}
   label={discount ? 'Special offer' : label}
   badge={discount ? `${discount}% Off` : badge}
   badgeIcon={discount ? null : badgeIcon}

--- a/src/ui/Pricing/SubscriptionSettings/index.svelte
+++ b/src/ui/Pricing/SubscriptionSettings/index.svelte
@@ -7,7 +7,7 @@
   import { getBusinessPlans, getIndividualPlans, queryPlans, queryPppSettings } from '@/api/plans'
   import { getCustomer$Ctx } from '@/stores/customer'
   import { paymentCard$ } from '@/stores/paymentCard'
-  import { Billing, Plan, PlanName, ProductId } from '@/utils/plans'
+  import { Billing, Plan, getPlanDisplayName, ProductId } from '@/utils/plans'
   import { checkIsActiveSubscription } from '@/utils/subscription'
   import Setting from './Setting.svelte'
   import UserPlanCard from './SubscriptionCard/UserPlanCard.svelte'
@@ -85,7 +85,7 @@
       />
 
       <PlanSuggestions suggestions={individualSuggestions} {plans} {isEligibleForTrial}>
-        <FullAccessCard currentPlanName={PlanName[plan.name]} />
+        <FullAccessCard currentPlanName={getPlanDisplayName(plan)} />
       </PlanSuggestions>
     </plans-section>
 

--- a/src/utils/plans.ts
+++ b/src/utils/plans.ts
@@ -37,17 +37,26 @@ export enum Plan {
 export const INDIVIDUAL_PLANS = new Set([Plan.FREE, Plan.PRO, Plan.MAX])
 export const BUSINESS_PLANS = new Set([Plan.BUSINESS_PRO, Plan.BUSINESS_MAX, Plan.CUSTOM])
 
-export const PlanName = {
-  [Plan.PRO_PLUS]: 'Pro+',
+export const getPlanDisplayName = ({
+  name,
+  product: { id: productId },
+}: Pick<SAN.Plan, 'product' | 'name'>) => {
+  const sanbasePlans: Partial<Record<string, string>> = {
+    [Plan.PRO_PLUS]: 'Pro+',
 
-  [Plan.FREE]: 'FREE',
-  [Plan.PRO]: 'Sanbase Pro',
-  [Plan.MAX]: 'Sanbase Max',
+    [Plan.FREE]: 'FREE',
+    [Plan.PRO]: 'Sanbase Pro',
+    [Plan.MAX]: 'Sanbase Max',
+  }
+  const businessPlans: Partial<Record<string, string>> = {
+    [Plan.BUSINESS_PRO]: 'Business Pro',
+    [Plan.BUSINESS_MAX]: 'Business Max',
+    [Plan.CUSTOM]: 'Enterprise',
+  }
+  const planNames = productId === ProductId.SANAPI ? businessPlans : sanbasePlans
 
-  [Plan.BUSINESS_PRO]: 'Business Pro',
-  [Plan.BUSINESS_MAX]: 'Business Max',
-  [Plan.CUSTOM]: 'Enterprise',
-} as const
+  return planNames[name] ?? `${ProductNameById[productId]} ${name}`
+}
 
 export enum Billing {
   MONTH = 'month',
@@ -59,9 +68,11 @@ export enum PlanType {
   BUSINESS = 'business',
 }
 
-export const checkIsIndividualPlan = ({ name }: { name: string }) =>
-  INDIVIDUAL_PLANS.has(name as Plan)
-export const checkIsBusinessPlan = ({ name }: { name: string }) => BUSINESS_PLANS.has(name as Plan)
+export const checkIsIndividualPlan = ({ product: { id: productId } }: Pick<SAN.Plan, 'product'>) =>
+  productId === ProductId.SANBASE
+
+export const checkIsBusinessPlan = ({ product: { id: productId } }: Pick<SAN.Plan, 'product'>) =>
+  productId === ProductId.SANAPI
 
 export const checkIsPlanWithPrice = ({ amount }: Pick<SAN.Plan, 'amount'>) => amount > 0
 

--- a/src/utils/subscription.ts
+++ b/src/utils/subscription.ts
@@ -1,7 +1,12 @@
 import type { CustomerData } from '@/stores/user'
 
 import { ONE_DAY_IN_MS } from './dates'
-import { PlanName, checkIsSanApiProduct, checkIsSanbaseProduct, checkIsYearlyPlan } from './plans'
+import {
+  getPlanDisplayName,
+  checkIsSanApiProduct,
+  checkIsSanbaseProduct,
+  checkIsYearlyPlan,
+} from './plans'
 
 export enum Status {
   ACTIVE = 'ACTIVE',
@@ -53,8 +58,7 @@ export function getUserSubscriptionInfo(
   const { isEligibleForTrial, annualDiscount } = customerData
   const annualDiscountPercent = annualDiscount?.isEligible && annualDiscount.discount?.percentOff
   const discountExpireAt = annualDiscount?.isEligible && annualDiscount.discount?.expireAt
-  const subscriptionPlan = subscription?.plan.name
-  const userPlanName = PlanName[subscriptionPlan] || subscriptionPlan
+  const userPlanName = getPlanDisplayName(subscription.plan)
   const trialDaysLeft = subscription?.trialEnd ? calculateTrialDaysLeft(subscription.trialEnd) : 0
 
   return {

--- a/stories/Subscription/Payment Dialog/index.stories.ts
+++ b/stories/Subscription/Payment Dialog/index.stories.ts
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from '@storybook/svelte'
 
-import { Billing, Plan } from '@/utils/plans'
+import { Billing, Plan, ProductId } from '@/utils/plans'
 import Component from './index.svelte'
 import { mockPlans } from './plans'
 
@@ -191,6 +191,7 @@ export const FixedPlans: Story = {
         interval: 'month',
         isDeprecated: false,
         name: Plan.PRO,
+        product: { id: ProductId.SANBASE },
       },
       {
         amount: 52900,
@@ -198,6 +199,7 @@ export const FixedPlans: Story = {
         interval: 'year',
         isDeprecated: false,
         name: Plan.PRO,
+        product: { id: ProductId.SANBASE },
       },
     ],
   },

--- a/stories/Subscription/SubscriptionSettings/index.stories.ts
+++ b/stories/Subscription/SubscriptionSettings/index.stories.ts
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/svelte'
 import Component from '@/ui/Pricing/SubscriptionSettings/index.svelte'
 import { mockPlans } from '../Payment Dialog/plans'
 import { pppMock } from './mock'
-import { Plan } from '@/utils/plans'
+import { Plan, ProductId } from '@/utils/plans'
 
 const meta = {
   // title: 'Design System/Icons',
@@ -167,6 +167,58 @@ export const BusinessProYearNoCard: Story = {
       currentUser: {
         plan: {
           name: Plan.BUSINESS_PRO,
+          productId: ProductId.SANAPI,
+          yearly: true,
+        },
+      },
+    }),
+  },
+}
+
+export const BusinessMaxYearNoCard: Story = {
+  parameters: {
+    mockApi: () => ({
+      ...mockPlans,
+      ...pppMock,
+      savedCard: false,
+      currentUser: {
+        plan: {
+          name: Plan.BUSINESS_MAX,
+          productId: ProductId.SANAPI,
+          yearly: true,
+        },
+      },
+    }),
+  },
+}
+
+export const CustomYearNoCard: Story = {
+  parameters: {
+    mockApi: () => ({
+      ...mockPlans,
+      ...pppMock,
+      savedCard: false,
+      currentUser: {
+        plan: {
+          name: Plan.CUSTOM,
+          productId: ProductId.SANAPI,
+          yearly: true,
+        },
+      },
+    }),
+  },
+}
+
+export const SanAPIProYearNoCard: Story = {
+  parameters: {
+    mockApi: () => ({
+      ...mockPlans,
+      ...pppMock,
+      savedCard: false,
+      currentUser: {
+        plan: {
+          name: Plan.PRO,
+          productId: ProductId.SANAPI,
           yearly: true,
         },
       },


### PR DESCRIPTION
## Summary
Add product id to plan identification logic to prevent ambiguity for plans with same name
Needed to fix case with old `SanAPI PRO` plan interpreted as `Sanbase PRO` and similar cases