### PR TITLE
Fixes required for Sanbase Svelte 5 update

### DIFF
--- a/src/ui/Dialog/Dialog.svelte
+++ b/src/ui/Dialog/Dialog.svelte
@@ -10,7 +10,7 @@
   let className = ''
   export { className as class }
   export let titleClassName = ''
-  export const closeDialog = (skipLockChecks = true) => requestDialogClose(skipLockChecks)
+  export let closeDialog: ((skipLockChecks?: boolean) => void) | undefined = undefined
   export let title: string | SvelteComponentModule = ''
   export let onBeforeDialogClose = () => {}
   export let noTitle = false
@@ -23,6 +23,7 @@
 
   const DialogCtx = $$props.DialogCtx as SAN.Dialog.Ctx
 
+  $: closeDialog = (skipLockChecks = true) => requestDialogClose(skipLockChecks)
   $: ({ i, DialogPromise } = $$props as SAN.Dialog.Props)
 
   let isOpening = true

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "moduleResolution": "node",
     "allowJs": true,
     "checkJs": true,
-    "target": "ES2017",
+    "target": "esnext",
     "module": "ESNext",
     "importsNotUsedAsValues": "error",
     "ignoreDeprecations": "5.0",


### PR DESCRIPTION
## Summary

1. Update tsconfig `target` to `esnext`. Old setting caused js rest operator to be polyfilled with duplicated `var` declaration in resulting function. This duplication caused compile error in Sanbase
2. Fix `closeDialog` prop declaration in `Dialog`. Prevents binding to const error with `bind:closeDialog` usage