### PR TITLE
fix(styles) Apply border hover only for btn

### DIFF
--- a/src/styles/layout.css
+++ b/src/styles/layout.css
@@ -5,7 +5,7 @@
   background: var(--white);
 }
 
-.border:hover {
+.btn.border:hover {
   border-color: var(--border-hover, var(---border));
 }
 


### PR DESCRIPTION
## Summary
Apply `.border` hover only for `.btn` to prevent conflict with `tailwind` border class

## Notion card
https://www.notion.so/santiment/Some-webkit-style-conflicts-00475be21d2c4694a69a753bdc46ed19?pvs=4
