### PR TITLE
fix(dialogs) Fix setting close handler in dialog context

### DIFF
--- a/src/ui/Dialog/Dialog.svelte
+++ b/src/ui/Dialog/Dialog.svelte
@@ -23,15 +23,18 @@
 
   const DialogCtx = $$props.DialogCtx as SAN.Dialog.Ctx
 
-  $: closeDialog = (skipLockChecks = true) => requestDialogClose(skipLockChecks)
-  $: ({ i, DialogPromise } = $$props as SAN.Dialog.Props)
-
   let isOpening = true
   let clickAwayMouseDown = false
   let openingTimer: number
 
-  DialogCtx.close = closeDialog
-  setDialogCtx(DialogCtx)
+  $: closeDialog = (skipLockChecks = true) => requestDialogClose(skipLockChecks)
+  $: setCloseInCtx(closeDialog)
+  $: ({ i, DialogPromise } = $$props as SAN.Dialog.Props)
+
+  function setCloseInCtx(close: (skipLockChecks?: boolean) => void) {
+    DialogCtx.close = close
+    setDialogCtx(DialogCtx)
+  }
 
   const checkIsEditable = ({ isContentEditable, localName }: HTMLElement): boolean =>
     isContentEditable || localName === 'input' || localName === 'textarea'


### PR DESCRIPTION
## Summary
Fix setting close handler in dialog context. Before fix handler in context sometimes was `undefined` preventing dialogs to close on some events (e.g. after selecting item from dialog)

## Notion card
https://www.notion.so/santiment/Asset-selector-doesn-t-close-after-selecting-asset-210351f4ee1e41b598b2e3779483094d?pvs=4
