### PR TITLE
feature(responsive) Make tw responsive selectors desktop-first

### DIFF
--- a/src/lib/ui/app/PaymentForm/Dialog.svelte
+++ b/src/lib/ui/app/PaymentForm/Dialog.svelte
@@ -32,14 +32,14 @@
   {/if}
 
   <ScreenTransition
-    class="flex gap-10 overflow-y-scroll bg-white px-36 pb-20 pt-16 xl:p-10 lg:flex-wrap lg:px-5"
+    class="flex gap-10 overflow-y-scroll bg-white px-36 pb-20 pt-16 lg:p-10 md:flex-wrap md:px-5"
     style="--plans-sticky-top: -65px"
   >
     {#if screen.$ === SCREENS[0]}
       <PlansScreen onPlanSelect={() => (screen.$ = SCREENS[1])}></PlansScreen>
     {:else}
-      <div class="w-full min-w-[400px] gap-10 self-start column lg:min-w-0">
-        <h1 class="color-rhino text-2xl font-medium lg:text-3xl">
+      <div class="w-full min-w-[400px] gap-10 self-start column md:min-w-0">
+        <h1 class="color-rhino text-2xl font-medium md:text-3xl">
           {#if subscriptionPlan.$.formatted}
             {subscriptionPlan.$.formatted.name} plan
           {:else}

--- a/src/lib/ui/app/PaymentForm/PaymentScreen/OrderSummary/Explanation.svelte
+++ b/src/lib/ui/app/PaymentForm/PaymentScreen/OrderSummary/Explanation.svelte
@@ -65,7 +65,7 @@
 {#if isConsumerPlan && customer.$.isEligibleForSanbaseTrial}
   <h2 class="text-base font-semibold text-rhino">How the Trial Works</h2>
 
-  <div class="relative gap-4 fill-waterloo pl-9 pr-16 text-waterloo column lg:pr-0">
+  <div class="relative gap-4 fill-waterloo pl-9 pr-16 text-waterloo column md:pr-0">
     {#snippet Step({
       name,
       icon,

--- a/src/lib/ui/app/PaymentForm/PaymentScreen/OrderSummary/index.svelte
+++ b/src/lib/ui/app/PaymentForm/PaymentScreen/OrderSummary/index.svelte
@@ -55,7 +55,7 @@
 </script>
 
 <div
-  class="min-w-[400px] max-w-[480px] gap-4 self-start column lg:mt-10 lg:min-w-0 lg:max-w-full lg:gap-2 lg:[&>*]:-mx-5 lg:[&>*]:rounded-none"
+  class="min-w-[400px] max-w-[480px] gap-4 self-start column md:mt-10 md:min-w-0 md:max-w-full md:gap-2 md:[&>*]:-mx-5 md:[&>*]:rounded-none"
 >
   <section class="gap-8 rounded-lg bg-athens px-8 py-6 column">
     <h2 class="text-lg font-semibold text-rhino">
@@ -165,7 +165,7 @@
   </section>
 
   {#if isCardPayment || isAnnualBilling}
-    <section class="gap-6 rounded-lg bg-athens px-8 py-6 text-rhino column lg:-mb-10">
+    <section class="gap-6 rounded-lg bg-athens px-8 py-6 text-rhino column md:-mb-10">
       <Explanation price={planPrice}></Explanation>
     </section>
   {/if}

--- a/src/lib/ui/app/PaymentForm/PaymentScreen/PaymentMethodSelector/index.svelte
+++ b/src/lib/ui/app/PaymentForm/PaymentScreen/PaymentMethodSelector/index.svelte
@@ -27,7 +27,7 @@
   active={selectedPaymentMethod}
   {options}
   {onSelect}
-  class="no-scrollbar sm:-mx-5 sm:flex-nowrap sm:overflow-auto sm:px-5"
+  class="no-scrollbar xs:-mx-5 xs:flex-nowrap xs:overflow-auto xs:px-5"
 >
   {#snippet children(option)}
     <h3 class="flex gap-2 center">

--- a/src/lib/ui/app/PaymentForm/Selector.svelte
+++ b/src/lib/ui/app/PaymentForm/Selector.svelte
@@ -31,7 +31,7 @@
       {@const isActive = option === active}
       <button
         class={cn(
-          'min-w-max gap-3 whitespace-nowrap rounded-lg border border-athens bg-athens px-4 py-[7px] column  lg:py-3',
+          'min-w-max gap-3 whitespace-nowrap rounded-lg border border-athens bg-athens px-4 py-[7px] column  md:py-3',
           !smallGap && 'flex-1',
           isActive && 'border-green bg-green-light-1',
         )}

--- a/src/lib/ui/core/Calendar/CalendarBody.svelte
+++ b/src/lib/ui/core/Calendar/CalendarBody.svelte
@@ -16,7 +16,7 @@
   const Base = range ? RangeCalendar : Calendar
 </script>
 
-<div class="month flex flex-col space-y-4 px-3 pb-3 pt-4 sm:flex-row sm:space-x-4 sm:space-y-0">
+<div class="month flex space-x-4 space-y-0 px-3 pb-3 pt-4 xs:flex-col xs:space-y-4">
   {#each months as month}
     <Base.Grid class="w-full border-collapse select-none space-y-1">
       <Base.GridHead>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -15,6 +15,13 @@ export default {
       },
     },
 
+    screens: {
+      lg: { max: '1279px' }, //Laptop
+      md: { max: '992px' }, //Tablet
+      sm: { max: '768x' }, //Phone
+      xs: { max: '480px' }, //Phone XS
+    },
+
     fontSize: {
       '2xs': ['10px', '14px'],
       xs: ['12px', '16px'],


### PR DESCRIPTION
## Summary

Add `screens` setting to tailwind config to set responsive breakpoints. Make them desktop-first. Breakpoints numbers are ~~tailwind defaults, but inverted. For example. `lg` was `min-width: 1024px`. Now `lg` is `max-width: 1279px`~~ taken from old responsive custom logic