### PR TITLE
Feature/account status

### DIFF
--- a/.storybook/mock/index.ts
+++ b/.storybook/mock/index.ts
@@ -1,6 +1,6 @@
-import { CURRENT_USER_MOCK } from './user'
-import { ANNUAL_DISCOUNT_MOCK } from './annualDiscount'
-import { SAVED_CARD_MOCK } from './savedCard'
+import { CURRENT_USER_MOCK } from './user.js'
+import { ANNUAL_DISCOUNT_MOCK } from './annualDiscount.js'
+import { SAVED_CARD_MOCK } from './savedCard.js'
 
 export const MOCKS = [CURRENT_USER_MOCK, ANNUAL_DISCOUNT_MOCK, SAVED_CARD_MOCK] as const
 export const MockedApi = MOCKS.reduce(

--- a/.storybook/mock/user.ts
+++ b/.storybook/mock/user.ts
@@ -1,10 +1,10 @@
 // import { getTodaysEnd } from '@/utils/dates'
-import { getTodaysEnd } from '../../src/lib/utils/dates'
+import { getTodaysEnd } from '../../src/lib/utils/dates.js'
 import {
   SubscriptionPlan,
   Product,
   checkIsBusinessPlan,
-} from '../../src/lib/ui/app/SubscriptionPlan'
+} from '../../src/lib/ui/app/SubscriptionPlan/index.js'
 
 export type CurrentUser = null | {
   /** @default 42 */
@@ -61,7 +61,7 @@ export type CurrentUser = null | {
     trial?: boolean
 
     /** @default undefined */
-    name?: typeof SubscriptionPlan
+    name?: string
 
     /** @default undefined */
     trialDaysLeft?: number
@@ -145,6 +145,7 @@ export function mockUser(currentUser: CurrentUser) {
       let name = planName
       if (pro) name = SubscriptionPlan.PRO.key
       else if (max) name = SubscriptionPlan.MAX.key
+      else if (proPlus) name = SubscriptionPlan.PRO_PLUS.key
       else if (businessPro) name = SubscriptionPlan.BUSINESS_PRO.key
       else if (businessMax) name = SubscriptionPlan.BUSINESS_MAX.key
       else if (custom) name = SubscriptionPlan.CUSTOM.key

--- a/src/lib/ui/app/AccountStatus.svelte
+++ b/src/lib/ui/app/AccountStatus.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import { useCustomerCtx } from '$lib/ctx/customer/index.js'
+  import Button from '$ui/core/Button/Button.svelte'
+  import { cn } from '$ui/utils/index.js'
+
+  const { currentUser, customer } = useCustomerCtx()
+</script>
+
+{#if currentUser.$$}
+  {#if customer.$.plan}
+    <div
+      class={cn(
+        'rounded-md px-3 py-1.5 uppercase',
+        customer.$.isBusinessSubscription
+          ? 'bg-blue-light-1 text-blue'
+          : 'bg-orange-light-1 text-orange',
+      )}
+    >
+      {customer.$.planName}
+    </div>
+  {:else}
+    <Button href="/pricing" variant="fill" class="bg-orange hover:bg-orange-hover">
+      {customer.$.isEligibleForSanbaseTrial ? 'Start Free 14-day Trial' : 'Upgrade'}
+    </Button>
+  {/if}
+{:else}
+  <Button href="/sign-up" variant="fill">Sign up</Button>
+{/if}

--- a/src/lib/ui/app/AccountStatus/AccountStatus.svelte
+++ b/src/lib/ui/app/AccountStatus/AccountStatus.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { useCustomerCtx } from '$lib/ctx/customer/index.js'
-  import Button from '$ui/core/Button/Button.svelte'
+  import Button from '$ui/core/Button/index.js'
   import { cn } from '$ui/utils/index.js'
 
   const { currentUser, customer } = useCustomerCtx()

--- a/src/lib/ui/app/AccountStatus/index.ts
+++ b/src/lib/ui/app/AccountStatus/index.ts
@@ -1,0 +1,1 @@
+export { default } from './AccountStatus.svelte'

--- a/src/stories/Design System - App UI/AccountStatus/index.stories.ts
+++ b/src/stories/Design System - App UI/AccountStatus/index.stories.ts
@@ -1,0 +1,108 @@
+import type { Meta, StoryObj } from '@storybook/svelte'
+import component from './index.svelte'
+
+const meta = {
+  component,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<component>
+type Story = StoryObj<typeof meta>
+
+export default meta
+
+export const Anonymous: Story = {
+  parameters: {
+    mockApi: () => ({
+      currentUser: null,
+    }),
+  },
+}
+
+export const FreeTrial: Story = {
+  name: 'Free - Trial is available',
+  parameters: {
+    mockApi: () => ({
+      currentUser: {
+        isEligibleForSanbaseTrial: true,
+      },
+    }),
+  },
+}
+
+export const FreeNoTrial: Story = {
+  name: 'Free - Trial is not available',
+  parameters: {
+    mockApi: () => ({
+      currentUser: {
+        isEligibleForSanbaseTrial: false,
+      },
+    }),
+  },
+}
+
+export const SanbasePro: Story = {
+  name: 'Sanbase Pro',
+  parameters: {
+    mockApi: () => ({
+      currentUser: {
+        plan: { pro: true, yearly: true },
+      },
+    }),
+  },
+}
+
+export const ProPlus: Story = {
+  name: 'Sanbase Pro+ (Deprecated)',
+  parameters: {
+    mockApi: () => ({
+      currentUser: {
+        plan: { proPlus: true, yearly: true },
+      },
+    }),
+  },
+}
+
+export const SanbaseMax: Story = {
+  name: 'Sanbase Max',
+  parameters: {
+    mockApi: () => ({
+      currentUser: {
+        plan: { max: true, yearly: true },
+      },
+    }),
+  },
+}
+
+export const BusinessPro: Story = {
+  name: 'Business Pro',
+  parameters: {
+    mockApi: () => ({
+      currentUser: {
+        plan: { businessPro: true, yearly: true },
+      },
+    }),
+  },
+}
+
+export const BusinessMax: Story = {
+  name: 'Business Max',
+  parameters: {
+    mockApi: () => ({
+      currentUser: {
+        plan: { businessMax: true, yearly: true },
+      },
+    }),
+  },
+}
+
+export const Enterprise: Story = {
+  name: 'Enterprise',
+  parameters: {
+    mockApi: () => ({
+      currentUser: {
+        plan: { custom: true, yearly: true },
+      },
+    }),
+  },
+}

--- a/src/stories/Design System - App UI/AccountStatus/index.svelte
+++ b/src/stories/Design System - App UI/AccountStatus/index.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import AccountStatus from '$ui/app/AccountStatus.svelte'
+  import AccountStatus from '$ui/app/AccountStatus/index.js'
 </script>
 
 <main class="flex min-h-[inherit] items-center justify-center">

--- a/src/stories/Design System - App UI/AccountStatus/index.svelte
+++ b/src/stories/Design System - App UI/AccountStatus/index.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  import AccountStatus from '$ui/app/AccountStatus.svelte'
+</script>
+
+<main class="flex min-h-[inherit] items-center justify-center">
+  <AccountStatus />
+</main>

--- a/src/stories/index.d.ts
+++ b/src/stories/index.d.ts
@@ -1,0 +1,1 @@
+import '../../.storybook/mock/index.ts'


### PR DESCRIPTION
## Summary
Add `AccountStatus` component

## Notion card
https://www.notion.so/santiment/Account-status-badge-migration-to-Svelte-5-572ecebb81154b4d8eeb082da960b704?pvs=4

## Screenshots
![image](https://github.com/user-attachments/assets/4c81fa80-5557-4df2-b9df-3b701444fd98)
