### PR TITLE
feature(icons) Add variables to change colors of warning illustration

### DIFF
--- a/src/lib/illus/warning.svg
+++ b/src/lib/illus/warning.svg
@@ -1,1 +1,7 @@
-<svg width="16" height="16" fill="none" xmlns="http://www.w3.org/2000/svg"><path d="M.9 10.19a3.1 3.1 0 0 1 0-4.38L5.82.91a3.1 3.1 0 0 1 4.38 0l4.9 4.9a3.1 3.1 0 0 1 0 4.38l-4.9 4.9a3.1 3.1 0 0 1-4.38 0l-4.9-4.9Z" fill="var(--bg-fill, var(--red-light-1,#FEE))"/><circle cx="8" cy="11.5" r=".75" fill="#FF6363"/><path d="M8 4v4.83" stroke="#FF6363" stroke-linecap="round" stroke-linejoin="round"/></svg>
+<svg width="16" height="16" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path
+    d="M.9 10.19a3.1 3.1 0 0 1 0-4.38L5.82.91a3.1 3.1 0 0 1 4.38 0l4.9 4.9a3.1 3.1 0 0 1 0 4.38l-4.9 4.9a3.1 3.1 0 0 1-4.38 0l-4.9-4.9Z"
+    fill="var(--bg-fill, var(--red-light-1,#FEE))" />
+  <circle cx="8" cy="11.5" r=".75" fill="var(--stroke-fill, var(--red, #FF6363))" />
+  <path d="M8 4v4.83" stroke="var(--stroke-fill, var(--red, #FF6363))" stroke-linecap="round" stroke-linejoin="round" />
+</svg>


### PR DESCRIPTION
## Summary

Add `--stroke-fill` variable to color exclamation mark in `warning` illustration icon

## Notion card
https://www.notion.so/santiment/Social-tool-design-update-1292a82d136180dbbf1ff47c8979e176?pvs=4