### PR TITLE
Feature/button plain

### DIFF
--- a/src/lib/ui/app/AccountDropdown/ProfilePicture.svelte
+++ b/src/lib/ui/app/AccountDropdown/ProfilePicture.svelte
@@ -21,6 +21,7 @@
 <Button
   {ref}
   {as}
+  variant="plain"
   style="--tw-ring-color:var(--{isBusinessPro ? 'blue' : isPro ? 'orange' : 'casper'})"
   class={cn(
     'flex size-8 rounded-full !fill-waterloo p-0 !text-waterloo center',

--- a/src/lib/ui/app/ScreenTransition/ScreenTransition.svelte
+++ b/src/lib/ui/app/ScreenTransition/ScreenTransition.svelte
@@ -144,6 +144,7 @@
             iconSize="14"
             icon="arrow-left-big"
             class="text-fiord"
+            variant="plain"
             onclick={() => {
               trackEvent('pagination', {
                 type: dataType,

--- a/src/lib/ui/app/classic/MobileHeader/MobileHeader.svelte
+++ b/src/lib/ui/app/classic/MobileHeader/MobileHeader.svelte
@@ -40,6 +40,7 @@
 
       <Button
         icon="search"
+        variant="plain"
         class="size-10 fill-black"
         iconSize={18}
         onclick={onSearchClick}

--- a/src/lib/ui/core/Button/Button.svelte
+++ b/src/lib/ui/core/Button/Button.svelte
@@ -111,9 +111,14 @@
         class: 'bg-[var(--accent,var(--green))] hover:bg-[var(--accent-hover,var(--green-hover))]',
       },
       {
-        variant: ['fill', 'border', 'ghost'],
+        variant: ['fill', 'border'],
         disabled: true,
         class: 'text-mystic fill-mystic bg-athens hover:bg-athens',
+      },
+      {
+        variant: 'ghost',
+        disabled: true,
+        class: 'text-mystic fill-mystic bg-transparent hover:bg-transparent',
       },
       {
         variant: ['title', 'link'],

--- a/src/lib/ui/core/Button/Button.svelte
+++ b/src/lib/ui/core/Button/Button.svelte
@@ -74,6 +74,7 @@
         ghost: 'px-2.5 fill-waterloo hover:bg-athens',
         title: 'rounded-none hover:underline',
         link: 'rounded-none text-green fill-green hover:underline',
+        plain: 'rounded-none',
       },
       iconOnRight: { true: 'flex-row-reverse justify-end' },
       explanation: { true: 'expl-tooltip' },

--- a/src/stories/Design System - Core UI/Buttons/index.svelte
+++ b/src/stories/Design System - Core UI/Buttons/index.svelte
@@ -54,6 +54,10 @@
         <StatesGroup title="Link" variant="link" />
 
         <StatesGroup title="Link Pointer" variant="link" icon="pointer" iconSize="10" iconOnRight />
+
+        <StatesGroup title="Plain (No styles)" variant="plain" />
+
+        <StatesGroup title="Plain Icon (No styles)" variant="plain" buttons={iconButtons} />
       </div>
     </section>
   </section>

--- a/src/stories/Design System - Core UI/Buttons/index.svelte
+++ b/src/stories/Design System - Core UI/Buttons/index.svelte
@@ -105,6 +105,7 @@
 
 {#snippet iconButtons(props: ComponentProps<typeof Button>)}
   <div class="flex flex-col gap-2">
+    <Button {...props} explanation="some info" icon="info" size="lg" />
     <Button {...props} explanation="some info" icon="info" />
     <Button {...props} explanation="some info" icon="info" size="sm" />
     <Button {...props} explanation="some info" icon="info" size="xs" />


### PR DESCRIPTION
## Summary
1. Add `plain` button variant for custom or "hidden" buttons
2. Change disabled `ghost` button bg from `athens` to `transparent`
3. Add more buttons to storybook
4. Make some buttons `plain`. Some buttons left with default variant (`ghost`)

## Notion card
https://www.notion.so/santiment/Design-system-Implement-new-Button-design-for-san-webkit-next-6419f5d7ab324d7d97ccc186e17aeea1?pvs=4

## Screenshots

### `src/lib/ui/app/CancelSubscriptionDialog/DialogHeader.svelte`
Close button is left `ghost` variant
![image](https://github.com/user-attachments/assets/c12034b0-1329-4d15-a812-f020deee664c)
![image](https://github.com/user-attachments/assets/bc71cfd6-a177-489e-999d-aac7fa63bdaf)


### `src/lib/ui/app/PaymentForm/DialogHeader.svelte`
Breadcrumbs are left with `ghost` variant
![image](https://github.com/user-attachments/assets/104e9c63-8443-4923-a84a-dbe0c30ae545)
![image](https://github.com/user-attachments/assets/8d76c2be-2765-4361-83c6-6b007586f0b4)

