### PR TITLE
feature(calendar) Add onChange for RangeCalendar, remove ability to b…

### DIFF
--- a/src/lib/ui/core/Calendar/Calendar.svelte
+++ b/src/lib/ui/core/Calendar/Calendar.svelte
@@ -16,14 +16,7 @@
     maxValue?: DateValue
     onChange?: (date: Date) => void
   }
-  let {
-    class: className,
-    date = $bindable(),
-    minValue,
-    maxValue,
-    timeZone,
-    onChange,
-  }: TProps = $props()
+  const { class: className, date, minValue, maxValue, timeZone, onChange }: TProps = $props()
 
   const value = $derived(fromDate(date, timeZone))
 
@@ -32,8 +25,7 @@
   const onValueChange = (update: DateValue | undefined) => {
     if (!update) return
 
-    date = update.toDate(timeZone)
-    onChange?.(date)
+    onChange?.(update.toDate(timeZone))
   }
 </script>
 

--- a/src/lib/ui/core/Calendar/RangeCalendar.svelte
+++ b/src/lib/ui/core/Calendar/RangeCalendar.svelte
@@ -11,13 +11,14 @@
   import CalendarBody from './CalendarBody.svelte'
   import CalendarHeader from './CalendarHeader.svelte'
 
-  let {
+  const {
     class: className,
-    date = $bindable(),
+    date,
     withPresets = false,
     minValue,
     maxValue,
     timeZone,
+    onChange,
   }: {
     class?: string
     date: [Date, Date]
@@ -25,6 +26,7 @@
     minValue?: DateValue
     maxValue?: DateValue
     timeZone: string
+    onChange?: (dates: [Date, Date]) => void
   } = $props()
 
   const value = $derived(getValue(date, timeZone))
@@ -38,7 +40,7 @@
     const endDateTime = toCalendarDateTime(end, new Time(23, 59, 59, 999))
     const startDateTime = toCalendarDateTime(start, new Time())
 
-    date = [startDateTime.toDate(timeZone), endDateTime.toDate(timeZone)]
+    onChange?.([startDateTime.toDate(timeZone), endDateTime.toDate(timeZone)])
   }
 
   function getValue([start, end]: [Date, Date], tz: string) {

--- a/src/stories/Design System - Core UI/Calendar/index.svelte
+++ b/src/stories/Design System - Core UI/Calendar/index.svelte
@@ -4,23 +4,38 @@
   let date = new Date()
   let dateOld = new Date(2017, 7, 9)
   let dates: [Date, Date] = [new Date(), new Date()]
+
+  function onChangeDate(_date: Date) {
+    date = _date
+    console.log('date changed')
+  }
+
+  function onChangeDates(_dates: [Date, Date]) {
+    dates = _dates
+    console.log('dates changed')
+  }
 </script>
 
 <div class="flex flex-col justify-center gap-4 p-6">
   <div class="flex flex-row items-center gap-2">
     Single date:
-    <DatePicker bind:date />
+    <DatePicker {date} onChange={onChangeDate} />
   </div>
   <div class="flex flex-row items-center gap-2">
     Single date 05/2015 - 07/2020:
-    <DatePicker bind:date={dateOld} minDate={new Date(2015, 4)} maxDate={new Date(2020, 6)} />
+    <DatePicker
+      date={dateOld}
+      onChange={(date: Date) => (dateOld = date)}
+      minDate={new Date(2015, 4)}
+      maxDate={new Date(2020, 6)}
+    />
   </div>
   <div class="flex flex-row items-center gap-2">
     Range:
-    <DatePicker date={dates} />
+    <DatePicker date={dates} onChange={onChangeDates} />
   </div>
   <div class="flex flex-row items-center gap-2">
     With Presets:
-    <DatePicker date={dates} withPresets />
+    <DatePicker date={dates} onChange={onChangeDates} withPresets />
   </div>
 </div>


### PR DESCRIPTION
## Summary

1. Add `onChange` prop support for range calendar

## Notion card
Some components pass `onChange` to range calendars for side effects and complex state update
https://www.notion.so/santiment/Update-buttons-in-Sanbase-1442a82d136180478c97e772abf2215f?pvs=4