### PR TITLE
fix(subscription) Fix displayed price with discount in PlanChangeDialog and SubscriptionSettings components

### DIFF
--- a/src/ui/Pricing/PlanChangeDialog.svelte
+++ b/src/ui/Pricing/PlanChangeDialog.svelte
@@ -12,7 +12,7 @@
   import { getCustomer$Ctx } from '@/stores/customer'
   import { Billing, formatPrice, PlanName } from '@/utils/plans'
   import { getDateFormats } from '@/utils/dates'
-  import { mutateUpdateSubscription } from '@/api/subscription'
+  import { mutateUpdateSubscription, queryUpcomingInvoice } from '@/api/subscription'
   import { onPlanChangeError, onPlanChangeSuccess } from './utils'
   import { SANBASE_ORIGIN } from '@/utils/links'
 
@@ -65,14 +65,15 @@
       </button>
     </div>
 
-    <p>
-      Your current plan ({currentPlanName}
-      {formatPrice(currentPlan)}/{currentPlan.interval}ly) is active until {formatDate()}. Starting
-      from this date your card will be charged {formatPrice(plan)} per {plan.interval}.{isNewBillingMonthly
-        ? ' With annual plan you can save up to 10%. '
-        : ''}
-      <a href="{SANBASE_ORIGIN}/account" class="btn">Update your billing information here.</a>
-    </p>
+    {#await queryUpcomingInvoice(subscription.id) then { upcomingInvoice }}}
+      <p>
+        Your current plan ({currentPlanName}
+        {formatPrice(upcomingInvoice)}/{currentPlan.interval}ly) is active until {formatDate()}.
+        Starting from this date your card will be charged {formatPrice(plan)} per
+        {plan.interval}.{isNewBillingMonthly ? ' With annual plan you can save up to 10%. ' : ''}
+        <a href="{SANBASE_ORIGIN}/account" class="btn">Update your billing information here.</a>
+      </p>
+    {/await}
 
     <actions class="row mrg-xl mrg--t">
       <button

--- a/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/UserPlanCard.svelte
+++ b/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/UserPlanCard.svelte
@@ -47,16 +47,10 @@
           {formatDate(new Date(subscription.currentPeriodEnd))}
         </b>
       {:else}
-        {@const price = formatPrice(plan)}
-        {#if trialDaysLeft}
-          Your card will be charged <b>{price} after</b> your trial will finish on
-          <b>{formatDate(new Date(subscription.trialEnd))}</b>
-        {:else}
-          {#await queryUpcomingInvoice(subscription.id) then { upcomingInvoice }}
-            Your card will be charged <b>{formatPrice(upcomingInvoice)} per {plan.interval}</b>. It
-            will automatically renewed on <b>{formatDate(new Date(upcomingInvoice.dueDate))}</b>
-          {/await}
-        {/if}
+        {#await queryUpcomingInvoice(subscription.id) then { upcomingInvoice }}
+          Your card will be charged <b>{formatPrice(upcomingInvoice)} per {plan.interval}</b>. It
+          will automatically renewed on <b>{formatDate(new Date(upcomingInvoice.dueDate))}</b>
+        {/await}
       {/if}
     {:else}
       Starter plan with limited access to Sanbase features. Check all plans


### PR DESCRIPTION
## Summary

Use `upcomingInvoice` data to show price of next payment in `SubscriptionSettings` and `PlanChangeDialog`

## Notion card

https://www.notion.so/santiment/Subscription-details-don-t-reflect-discounts-15a2a82d1361800aa347c237acadc246?pvs=4