### PR TITLE
fix(dialog) Add height 100% to mobile dialog and change wrapper tag for easy styles overwrite

### DIFF
--- a/src/lib/ui/core/Dialog/Responsive/MobileDialog.svelte
+++ b/src/lib/ui/core/Dialog/Responsive/MobileDialog.svelte
@@ -69,9 +69,9 @@
         ></span>
       </div>
 
-      <div class="relative w-full overflow-hidden rounded-t-[10px] column">
+      <section class="relative h-full w-full overflow-hidden rounded-t-[10px] column">
         {@render children({ close })}
-      </div>
+      </section>
     </div>
   </div>
 {/if}


### PR DESCRIPTION
## Summary

1. Add `height: 100%` to mobile dialogs. In some cases there is no way to extend dialog content to full height (ex VirtualList)
2. Change children wrapper tag to `section` from `div` for easier styles overwrite
