### PR TITLE
chore(utils) Export exactObjectKeys for external use

### DIFF
--- a/src/lib/utils/index.ts
+++ b/src/lib/utils/index.ts
@@ -3,7 +3,7 @@ import { getContext, setContext } from 'svelte'
 
 export type { TNominal } from './types/index.js'
 
-export { keyify } from './object.js'
+export { keyify, exactObjectKeys } from './object.js'
 
 export { useObserveFnCall, pipeGroupBy } from './observable.svelte.js'
 


### PR DESCRIPTION
## Summary

Export `exactObjectKeys` helper function for external usage