### PR TITLE
feat: `Share` migration

### DIFF
--- a/src/lib/ui/core/Share/Share.svelte
+++ b/src/lib/ui/core/Share/Share.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import Button from '$ui/core/Button/index.js'
+  import { cn } from '$ui/utils/index.js'
+  import { copy } from '$lib/utils/clipboard.js'
+
+  import { showShareDialog$ } from './ShareDialog.svelte'
+
+  type TProps = {
+    class?: string
+    getLink: () => Promise<string>
+  }
+
+  const { class: className = '', getLink }: TProps = $props()
+
+  let explanation = $state('Copy link')
+
+  const showShareDialog = showShareDialog$()
+
+  function onShareClick() {
+    getLink().then((link) => {
+      showShareDialog({ data: { link }, feature: 'chart_layout', source: 'charts' })
+    })
+  }
+
+  function onCopyLinkClick() {
+    explanation = 'Copied!'
+    getLink().then((link) => {
+      copy(link, () => (explanation = 'Copy link'), 1500)
+    })
+  }
+</script>
+
+<div class={cn('flex items-center', className)}>
+  <Button onclick={onShareClick} class="rounded-none rounded-l-md px-3.5 py-1.5" variant="fill">
+    Share
+  </Button>
+  <Button
+    icon="link"
+    variant="fill"
+    class="rounded-none rounded-r-md border-l border-l-white py-1.5"
+    onclick={onCopyLinkClick}
+    {explanation}
+  ></Button>
+</div>

--- a/src/lib/ui/core/Share/Share.svelte
+++ b/src/lib/ui/core/Share/Share.svelte
@@ -2,15 +2,18 @@
   import Button from '$ui/core/Button/index.js'
   import { cn } from '$ui/utils/index.js'
   import { copy } from '$lib/utils/clipboard.js'
+  import { trackEvent } from '$lib/analytics/index.js'
 
   import { showShareDialog$ } from './ShareDialog.svelte'
 
   type TProps = {
-    class?: string
     getLink: () => Promise<string>
+    class?: string
+    source?: string
+    feature?: string
   }
 
-  const { class: className = '', getLink }: TProps = $props()
+  const { class: className = '', getLink, feature, source }: TProps = $props()
 
   let explanation = $state('Copy link')
 
@@ -18,15 +21,18 @@
 
   function onShareClick() {
     getLink().then((link) => {
-      showShareDialog({ data: { link }, feature: 'chart_layout', source: 'charts' })
+      showShareDialog({ data: { link }, feature, source })
     })
   }
 
   function onCopyLinkClick() {
     explanation = 'Copied!'
+
     getLink().then((link) => {
       copy(link, () => (explanation = 'Copy link'), 1500)
     })
+
+    trackEvent('press', { type: 'quick_link_copy', source })
   }
 </script>
 

--- a/src/lib/ui/core/Share/ShareDialog.svelte
+++ b/src/lib/ui/core/Share/ShareDialog.svelte
@@ -1,0 +1,169 @@
+<script module lang="ts">
+  import Component from './ShareDialog.svelte'
+
+  export const showShareDialog$ = () => dialogs$.new(Component)
+
+  type Social = {
+    id: string
+    href: (p: { link: string; text: string; title: string }) => string
+  }
+
+  const SOCIALS = [
+    {
+      id: 'twitter',
+      href: ({ link, text }) => `https://twitter.com/intent/tweet?title=${text}&url=${link}`,
+    },
+    {
+      id: 'facebook',
+      href: ({ link }) => `https://www.facebook.com/sharer/sharer.php?u=${link}`,
+    },
+    {
+      id: 'linked-in',
+      href: ({ link, text, title }) =>
+        `https://www.linkedin.com/shareArticle?mini=true&title=${title}&summary=${text}&source=santiment.net&url=${link}`,
+    },
+    {
+      id: 'telegram',
+      href: ({ link, text }) => `https://telegram.me/share/url?text=${text}&url=${link}`,
+    },
+    {
+      id: 'reddit',
+      href: ({ link, text }) => `https://reddit.com/submit?title=${text}&url=${link}`,
+    },
+  ] satisfies Social[]
+</script>
+
+<script lang="ts">
+  import { onMount } from 'svelte'
+
+  import Dialog, { dialogs$, type TDialogProps } from '$ui/core/Dialog/index.js'
+  import Button from '$ui/core/Button/index.js'
+  import Svg from '$ui/core/Svg/index.js'
+  import Switch from '$ui/core/Switch/index.js'
+  import { copy } from '$lib/utils/clipboard.js'
+  import { cn } from '$ui/utils/index.js'
+  import { trackEvent } from '$lib/analytics/index.js'
+
+  type TProps = {
+    title?: string
+    entity?: string
+    data?: { title?: string; text?: string; link?: string }
+    isAuthor?: boolean
+    isPublic?: boolean
+    onPublicityToggle?: VoidFunction
+    feature?: string
+    source?: string
+  } & TDialogProps
+
+  const {
+    title = 'Share',
+    entity = 'Watchlist',
+    data = {},
+    isAuthor = false,
+    isPublic = false,
+    onPublicityToggle = () => {},
+    feature,
+    source,
+    Controller,
+  }: TProps = $props()
+
+  const {
+    title: shareTitle = 'Sanbase',
+    text = 'Hey! Look what I have found at the app.santiment.net!',
+    link = window.location.href,
+  } = data
+
+  const encodedTitle = encodeURIComponent(shareTitle)
+  const encodedText = encodeURIComponent(text)
+
+  let inputNode = $state<HTMLInputElement>()
+  let label = $state('Copy link')
+
+  const disabled = $derived(isAuthor && !isPublic)
+
+  function onCopy() {
+    label = 'Copied!'
+    copy(link, () => (label = 'Copy link'), 1000, inputNode)
+  }
+
+  onMount(() => {
+    trackEvent('dialog', { action: 'open', type: 'share_dialog', feature, source })
+
+    return () => trackEvent('dialog', { action: 'close', type: 'share_dialog', feature, source })
+  })
+</script>
+
+<Dialog>
+  <header class="flex items-center justify-between border-b border-b-porcelain px-5 py-3">
+    <h2 class="text-base">{title}</h2>
+    <Button
+      icon="close"
+      class="size-3 fill-waterloo hover:bg-transparent hover:fill-green"
+      iconSize={10}
+      onclick={() => Controller.close(true)}
+    />
+  </header>
+
+  <div class="w-[600px] px-6 py-5 sm:w-auto sm:max-w-[600px]">
+    {#if disabled}
+      <div class="mb-4 rounded bg-orange-light-1 px-4 py-2.5 font-medium text-orange">
+        Your {entity} is private. Please, switch it to "Public" first.
+      </div>
+    {/if}
+
+    <div
+      class={cn(
+        'link mb-6 flex h-[42px] items-center overflow-hidden rounded border',
+        disabled && 'pointer-events-none bg-athens',
+      )}
+    >
+      <input
+        readonly
+        value={link}
+        class={cn(
+          'h-full w-full border-none bg-transparent px-2.5 py-1.5 focus:outline-none',
+          disabled ? 'text-mystic' : 'text-waterloo',
+        )}
+        bind:this={inputNode}
+      />
+      <Button
+        class={cn(
+          'h-full min-w-[84px] items-center justify-center',
+          'text-nowrap rounded-none border-l border-l-porcelain',
+          'px-3 py-2.5 text-center hover:text-green',
+          disabled ? 'text-mystic' : 'text-black',
+        )}
+        variant="plain"
+        onclick={onCopy}
+        {disabled}
+      >
+        {label}
+      </Button>
+    </div>
+
+    <p class="mb-3">Share on social media</p>
+    <div class="flex gap-3">
+      {#each SOCIALS as { id, href }}
+        <a
+          href={href({ link, title: encodedTitle, text: encodedText })}
+          class={cn(
+            'flex h-10 w-10 items-center justify-center rounded border border-porcelain hover:fill-green',
+            disabled && 'pointer-events-none bg-athens fill-waterloo text-mystic',
+          )}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <Svg {id} w="18" h="20" />
+        </a>
+      {/each}
+
+      {#if isAuthor}
+        <button class="ml-auto flex items-center" onclick={onPublicityToggle}>
+          {isPublic ? 'Public' : 'Private'}
+          {entity}
+          <Switch class="ml-3 cursor-pointer" checked={isPublic} disabled></Switch>
+        </button>
+      {/if}
+    </div>
+  </div>
+</Dialog>

--- a/src/lib/ui/core/Share/ShareDialog.svelte
+++ b/src/lib/ui/core/Share/ShareDialog.svelte
@@ -38,7 +38,6 @@
 
   import Dialog, { dialogs$, type TDialogProps } from '$ui/core/Dialog/index.js'
   import Button from '$ui/core/Button/index.js'
-  import Svg from '$ui/core/Svg/index.js'
   import Switch from '$ui/core/Switch/index.js'
   import { copy } from '$lib/utils/clipboard.js'
   import { cn } from '$ui/utils/index.js'
@@ -142,27 +141,29 @@
     </div>
 
     <p class="mb-3">Share on social media</p>
-    <div class="flex gap-3">
+    <div class="flex items-center gap-3">
       {#each SOCIALS as { id, href }}
-        <a
+        <Button
           href={href({ link, title: encodedTitle, text: encodedText })}
           class={cn(
-            'flex h-10 w-10 items-center justify-center rounded border border-porcelain hover:fill-green',
+            'flex h-10 w-10 items-center justify-center rounded border border-porcelain fill-black hover:bg-transparent hover:fill-green',
             disabled && 'pointer-events-none bg-athens fill-waterloo text-mystic',
           )}
           target="_blank"
-          rel="noopener noreferrer"
-        >
-          <Svg {id} w="18" h="20" />
-        </a>
+          icon={id}
+          iconSize={18}
+          iconHeight={20}
+        ></Button>
       {/each}
 
       {#if isAuthor}
-        <button class="ml-auto flex items-center" onclick={onPublicityToggle}>
+        <Button as="label" class="ml-auto flex items-center">
           {isPublic ? 'Public' : 'Private'}
           {entity}
-          <Switch class="ml-3 cursor-pointer" checked={isPublic} disabled></Switch>
-        </button>
+
+          <Switch class="ml-3 cursor-pointer" checked={isPublic} onCheckedChange={onPublicityToggle}
+          ></Switch>
+        </Button>
       {/if}
     </div>
   </div>

--- a/src/lib/ui/core/Share/index.ts
+++ b/src/lib/ui/core/Share/index.ts
@@ -1,0 +1,2 @@
+export { default } from './Share.svelte'
+export { showShareDialog$ } from './ShareDialog.svelte'

--- a/src/lib/utils/clipboard.ts
+++ b/src/lib/utils/clipboard.ts
@@ -1,0 +1,36 @@
+function newCopyNode(text: string): HTMLTextAreaElement {
+  const node = document.createElement('textarea')
+  node.value = text
+  node.setAttribute('style', 'position:absolute;left:-100vh')
+  document.body.appendChild(node)
+  return node
+}
+
+export function copy(
+  text: string,
+  callback: () => void,
+  timeout = 1000,
+  node?: HTMLInputElement | HTMLTextAreaElement,
+): () => void {
+  const timer = setTimeout(callback, timeout)
+
+  if (navigator.clipboard?.writeText) {
+    navigator.clipboard.writeText(text).catch((err) => {
+      console.error('Clipboard API failed, falling back:', err)
+      fallback()
+    })
+  } else {
+    fallback()
+  }
+
+  function fallback() {
+    const shouldRemoveNode = !node
+    node = node || newCopyNode(text)
+    node.select()
+    document.execCommand('copy')
+
+    if (shouldRemoveNode) node.remove()
+  }
+
+  return () => clearTimeout(timer)
+}

--- a/src/stories/Design System - Core UI/Share/index.stories.ts
+++ b/src/stories/Design System - Core UI/Share/index.stories.ts
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/svelte'
+
+import component from './index.svelte'
+
+const meta = {
+  component,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<component>
+type Story = StoryObj<typeof meta>
+
+export default meta
+
+export const Share: Story = {}

--- a/src/stories/Design System - Core UI/Share/index.svelte
+++ b/src/stories/Design System - Core UI/Share/index.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import Share from '$ui/core/Share/Share.svelte'
+
+  const getLink = () => Promise.resolve('https://app.santiment.net/s/YBVJyqVw')
+</script>
+
+<div class="flex h-screen items-center justify-center">
+  <Share {getLink} />
+</div>

--- a/src/stories/Design System - Core UI/Share/index.svelte
+++ b/src/stories/Design System - Core UI/Share/index.svelte
@@ -5,5 +5,5 @@
 </script>
 
 <div class="flex h-screen items-center justify-center">
-  <Share {getLink} />
+  <Share {getLink} feature="chart_layout" source="charts" />
 </div>


### PR DESCRIPTION
### Description

1. Migrated `Share` button and `ShareDialog` to Svelte 5
2. Moved share link generation context dependent logic out of the component - now passed in as a getLink prop.
3. Updated `copy()` utility to use `navigator.clipboard.writeText()` with a fallback to `execCommand` for legacy support

### Notion's task

https://www.notion.so/santiment/Migrate-share-component-to-san-webkit-next-2082a82d136180b39662f7fba5de19b0