### PR TITLE
Feat/add current user props

### DIFF
--- a/src/lib/ctx/customer/api.ts
+++ b/src/lib/ctx/customer/api.ts
@@ -236,23 +236,18 @@ export function loadCustomerData(
       const apiSubscription = getApiSubscription(subscriptions)
       const primarySubscription = getPrimarySubscription(subscriptions)
 
-      update(
-        Object.assign(
-          {},
-          defaultValue,
-          //currentUser,
-          { currentUser, isEligibleForSanbaseTrial },
-          getCustomerSubscriptionData(primarySubscription),
-          {
-            isLoggedIn: true,
-            isEarlyAccessMember: checkIsEarlyAccessMember(currentUser),
+      update({
+        ...defaultValue,
+        currentUser,
+        isEligibleForSanbaseTrial,
+        ...getCustomerSubscriptionData(primarySubscription),
+        isLoggedIn: true,
+        isEarlyAccessMember: checkIsEarlyAccessMember(currentUser),
 
-            primarySubscription,
-            sanbaseSubscription,
-            apiSubscription,
-          },
-        ),
-      )
+        primarySubscription,
+        sanbaseSubscription,
+        apiSubscription,
+      })
 
       sanBalancePromise
         .then((data) => update({ sanBalance: data?.sanBalance ?? 0 }))

--- a/src/lib/ctx/customer/api.ts
+++ b/src/lib/ctx/customer/api.ts
@@ -137,8 +137,10 @@ const queryCurrentUser = ApiQuery(
     firstLogin
     isModerator
     isEligibleForSanbaseTrial
+    areUserAffiliateDatailsSubmitted
     featureAccessLevel
     ethAccounts { address }
+    apikeys
     ${BROWSER ? 'following { users { id } }' : ''}
     settings {
       theme
@@ -146,6 +148,7 @@ const queryCurrentUser = ApiQuery(
       sanbaseVersion
       alertNotifyEmail
       alertNotifyTelegram
+      hasTelegramConnected
     }
     subscriptions {
       id

--- a/src/lib/ctx/customer/api.ts
+++ b/src/lib/ctx/customer/api.ts
@@ -14,32 +14,7 @@ import {
 } from '$ui/app/SubscriptionPlan/subscription.js'
 
 export type TCustomer = {
-  currentUser: null | {
-    id: string
-    email: null | string
-    name: null | string
-    username: null | string
-    avatarUrl: null | string
-    privacyPolicyAccepted: boolean
-    marketingAccepted: boolean
-    firstLogin: boolean
-    isModerator: boolean
-    featureAccessLevel: 'ALPHA' | 'BETA' | 'RELEASED'
-
-    following?: {
-      users: { id: string | number }[]
-    }
-
-    settings: {
-      theme: null | 'nightmode'
-      isPromoter: boolean
-      sanbaseVersion: null | string
-      alertNotifyEmail: boolean
-      alertNotifyTelegram: boolean
-    }
-
-    ethAccounts: { address: string }[]
-  }
+  currentUser: null | TCurrentUser
 
   isLoggedIn: boolean
 
@@ -116,6 +91,39 @@ export const DEFAULT: TCustomer = {
   subscriptions: [],
 }
 
+export type TCurrentUser = {
+  id: string
+  email: null | string
+  name: null | string
+  username: null | string
+  avatarUrl: null | string
+  privacyPolicyAccepted: boolean
+  marketingAccepted: boolean
+  firstLogin: boolean
+  isModerator: boolean
+  featureAccessLevel: 'ALPHA' | 'BETA' | 'RELEASED'
+
+  following?: {
+    users: { id: string }[]
+  }
+
+  settings: {
+    theme: null | 'nightmode'
+    isPromoter: boolean
+    sanbaseVersion: null | string
+    alertNotifyEmail: boolean
+    alertNotifyTelegram: boolean
+    hasTelegramConnected: boolean
+  }
+
+  ethAccounts: { address: string }[]
+  apikeys: string[]
+
+  isEligibleForSanbaseTrial: boolean
+  areUserAffiliateDatailsSubmitted: boolean
+  subscriptions: null | TSubscription[]
+}
+
 export const queryCurrentUserSubscriptions = ApiQuery(
   () => `{
   currentUser {
@@ -155,37 +163,7 @@ export const queryCurrentUserSubscriptions = ApiQuery(
     }
   }
 }`,
-  (gql: {
-    currentUser: null | {
-      id: string
-      email: null | string
-      name: null | string
-      username: null | string
-      avatarUrl: null | string
-      privacyPolicyAccepted: boolean
-      marketingAccepted: boolean
-      firstLogin: boolean
-      isModerator: boolean
-      featureAccessLevel: string
-
-      following?: {
-        users: { id: string | number }[]
-      }
-
-      settings: {
-        theme: null | 'nightmode'
-        isPromoter: boolean
-        sanbaseVersion: null | string
-        alertNotifyEmail: boolean
-        alertNotifyTelegram: boolean
-      }
-
-      ethAccounts: { address: string }[]
-
-      isEligibleForSanbaseTrial: boolean
-      subscriptions: null | TSubscription[]
-    }
-  }) => gql.currentUser,
+  (gql: { currentUser: null | TCurrentUser }) => gql.currentUser,
   { cache: false },
 )
 

--- a/src/lib/ctx/customer/api.ts
+++ b/src/lib/ctx/customer/api.ts
@@ -124,7 +124,7 @@ export type TCurrentUser = {
   subscriptions: null | TSubscription[]
 }
 
-export const queryCurrentUserSubscriptions = ApiQuery(
+const queryCurrentUser = ApiQuery(
   () => `{
   currentUser {
     id
@@ -222,10 +222,10 @@ export function loadCustomerData(
   const executor = UniQuery(fetcher)
   const defaultValue = Object.assign({}, DEFAULT)
 
-  const subscriptionsPromise = queryCurrentUserSubscriptions(executor)()
+  const currentUserPromise = queryCurrentUser(executor)()
   const sanBalancePromise = BROWSER ? queryCurrentUserSanBalance(executor)() : Promise.resolve()
 
-  return subscriptionsPromise
+  return currentUserPromise
     .then((currentUser) => {
       if (!currentUser) return update(defaultValue)
 
@@ -265,7 +265,7 @@ export function loadCustomerData(
 }
 
 function checkIsEarlyAccessMember(
-  currentUser: NonNullable<API.ExtractData<typeof queryCurrentUserSubscriptions>>,
+  currentUser: NonNullable<API.ExtractData<typeof queryCurrentUser>>,
 ): boolean {
   const { email, featureAccessLevel } = currentUser
   return (

--- a/src/lib/ui/app/SubscriptionPlan/subscription.ts
+++ b/src/lib/ui/app/SubscriptionPlan/subscription.ts
@@ -129,7 +129,7 @@ export function getCustomerSubscriptionData(subscription: null | TSubscription) 
 
       isCanceledSubscription: !!cancelAtPeriodEnd,
       isIncompleteSubscription: checkIsIncompleteSubscription(subscription),
-      isTrialSubscription: trialDaysLeft && trialDaysLeft > 0 && status === Status.TRIALING,
+      isTrialSubscription: !!trialDaysLeft && trialDaysLeft > 0 && status === Status.TRIALING,
       trialDaysLeft,
 
       currentPeriodEnd,


### PR DESCRIPTION
## Summary
1. Add fields to `currentUser` to replace old context

## Notion card
https://www.notion.so/santiment/Current-user-context-refactor-2252a82d1361807093c8e45f593c4443?source=copy_link
