### PR TITLE
refactor(current user) Update currentUser prop in different component to require only used fields

### DIFF
--- a/src/analytics/events/interaction.ts
+++ b/src/analytics/events/interaction.ts
@@ -52,7 +52,7 @@ export const trackProfileClick = ({
   feature,
   source,
 }: {
-  id: number
+  id: number | string
   feature?: string
   username?: string
   source: string

--- a/src/api/web3.ts
+++ b/src/api/web3.ts
@@ -14,8 +14,8 @@ type AddUserEthAddressMutation = SAN.API.Query<
   'addUserEthAddress',
   {
     ethAccounts: {
-      address: string[]
-    }
+      address: string
+    }[]
   }
 >
 

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -86,7 +86,7 @@ export type PromoCode = {
 }
 
 export type CurrentUserType = {
-  id: number
+  id: string
   email: string | null
   username: string | null
   name: string | null

--- a/src/stores/user.ts
+++ b/src/stores/user.ts
@@ -86,7 +86,7 @@ export type PromoCode = {
 }
 
 export type CurrentUserType = {
-  id: string
+  id: string | number
   email: string | null
   username: string | null
   name: string | null

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -1,6 +1,6 @@
 declare namespace SAN {
   type Author = {
-    id: number
+    id: string
     username?: string | null
     email?: string | null
     avatarUrl?: string | null

--- a/src/types/user.d.ts
+++ b/src/types/user.d.ts
@@ -1,6 +1,6 @@
 declare namespace SAN {
   type Author = {
-    id: string
+    id: string | number
     username?: string | null
     email?: string | null
     avatarUrl?: string | null

--- a/src/ui/Comments/Comment.svelte
+++ b/src/ui/Comments/Comment.svelte
@@ -14,7 +14,7 @@
   export let commentsFor: SAN.CommentsFor
   export let comment: SAN.Comment
   export let authorId: number
-  export let currentUser: null | SAN.CurrentUser = null
+  export let currentUser: null | { id: string } = null
   export let updateComments: any
   export let scrollToNewComment: () => void
   export let commentsNode: HTMLDivElement
@@ -61,6 +61,7 @@ Edited: ${getDatetime(editedAt)}`
     </div>
   </div>
 
+  <!-- eslint-disable-next-line svelte/no-at-html-tags -->
   <div class="content mrg-s mrg--t">{@html html}</div>
 
   {#if currentUser}

--- a/src/ui/Comments/Comment.svelte
+++ b/src/ui/Comments/Comment.svelte
@@ -14,7 +14,7 @@
   export let commentsFor: SAN.CommentsFor
   export let comment: SAN.Comment
   export let authorId: number
-  export let currentUser: null | { id: string } = null
+  export let currentUser: null | { id: string | number } = null
   export let updateComments: any
   export let scrollToNewComment: () => void
   export let commentsNode: HTMLDivElement
@@ -70,7 +70,7 @@ Edited: ${getDatetime(editedAt)}`
         <button class="reply btn" on:click={onReply}>Reply</button>
       {/if}
 
-      {#if currentUser.id === user.id}
+      {#if +currentUser.id === +user.id}
         <Menu bind:comment {commentsNode} />
       {/if}
     </div>

--- a/src/ui/Comments/Tooltips/UserInfo.svelte
+++ b/src/ui/Comments/Tooltips/UserInfo.svelte
@@ -16,9 +16,10 @@
 <script lang="ts">
   import type { CreationType } from '@/ui/Profile/types'
   import Info from '@/ui/Profile/Info.svelte'
+  import { ComponentProps } from 'svelte'
 
   export let id: number
-  export let currentUser
+  export let currentUser: ComponentProps<Info>['currentUser']
   export let type: CreationType
 
   let user = null

--- a/src/ui/Comments/Tooltips/UserInfoCtx.svelte
+++ b/src/ui/Comments/Tooltips/UserInfoCtx.svelte
@@ -1,5 +1,5 @@
 <script context="module" lang="ts">
-  import { getContext, setContext, tick } from 'svelte'
+  import { ComponentProps, getContext, setContext, tick } from 'svelte'
 
   const ID = 'UserInfoTooltipCtx'
   export const getUserInfoTooltip = () => getContext(ID)
@@ -22,7 +22,7 @@
   export let comments: any[]
   export let commentsNode: HTMLElement
   export let type: CommentsType
-  export let currentUser
+  export let currentUser: ComponentProps<UserInfo>['currentUser']
 
   const once = { once: true }
   const Type = {

--- a/src/ui/Comments/index.svelte
+++ b/src/ui/Comments/index.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { BROWSER } from 'esm-env'
-  import { onDestroy } from 'svelte'
+  import { ComponentProps, onDestroy } from 'svelte'
   import { track } from '@/analytics'
   import { CommentsType, queryComments } from '@/api/comments'
   import { createComment } from '@/api/comments/mutate'
@@ -16,7 +16,7 @@
 
   export let type: CommentsType
   export let commentsFor: SAN.CommentsFor
-  export let currentUser: null | SAN.CurrentUser = null
+  export let currentUser: ComponentProps<UserInfoTooltipCtx>['currentUser'] = null
   export let onNewComment: (commentsFor: SAN.CommentsFor, comments: SAN.Comment[]) => void
   export let onAnonComment: () => void = noop
   export let onCommentError = noop

--- a/src/ui/CreationInfo/HoverEdit.svelte
+++ b/src/ui/CreationInfo/HoverEdit.svelte
@@ -1,9 +1,9 @@
-<script>
+<script lang="ts">
   import Tooltip from '@/ui/Tooltip/svelte'
 
   let className = ''
   export { className as class }
-  export let currentUser
+  export let currentUser: object | null
   export let editLabel = 'Edit'
   export let titleHoverTooltipClass = ''
   export let onEditClick

--- a/src/ui/CreationInfo/HoverEdit.svelte
+++ b/src/ui/CreationInfo/HoverEdit.svelte
@@ -3,14 +3,14 @@
 
   let className = ''
   export { className as class }
-  export let currentUser: object | null
+  export let isLoggedIn: boolean
   export let editLabel = 'Edit'
   export let titleHoverTooltipClass = ''
   export let onEditClick
 </script>
 
 <Tooltip
-  isEnabled={!!currentUser}
+  isEnabled={isLoggedIn}
   openDelay={110}
   duration={65}
   dark
@@ -18,11 +18,13 @@
   align="center"
   class="caption {titleHoverTooltipClass}"
 >
+  <!-- svelte-ignore a11y-click-events-have-key-events -->
+  <!-- svelte-ignore a11y-no-static-element-interactions -->
   <span
     slot="trigger"
     class="btn {className}"
-    class:enabled={currentUser}
-    on:click={currentUser ? onEditClick : null}
+    class:enabled={isLoggedIn}
+    on:click={isLoggedIn ? onEditClick : null}
   >
     <slot />
   </span>

--- a/src/ui/CreationInfo/index.svelte
+++ b/src/ui/CreationInfo/index.svelte
@@ -15,7 +15,7 @@
   export let id = null as null | number
   export let title = null as null | string
   export let user = null as null | SAN.Author
-  export let currentUser: SAN.CurrentUser | null
+  export let currentUser: { id: string; following?: { users: { id: string }[] } } | null
   export let onEditClick: () => any
   export let type: CreationType
   export let fallback = 'Unsaved layout'
@@ -23,7 +23,7 @@
   export let comments: {
     count: number
     active?: boolean
-    onClick: () => any
+    onClick: (e?: any) => any
   }
   export let votes = null as null | Votes
   export let onVote
@@ -41,7 +41,7 @@
         </svelte:fragment>
 
         <svelte:fragment slot="tooltip">
-          <Info {user} {type} feature={type} {currentUser} />
+          <Info {user} {type} {currentUser} />
         </svelte:fragment>
       </Tooltip>
 

--- a/src/ui/FollowButton/flow.ts
+++ b/src/ui/FollowButton/flow.ts
@@ -5,7 +5,7 @@ export const ANON_EVENT = 'ANON_FOLLOW_CLICKED'
 
 type Id = number | string
 export type CurrentUser = {
-  following: {
+  following?: {
     users: {
       id: Id
     }[]
@@ -13,10 +13,10 @@ export type CurrentUser = {
 }
 
 export const checkIsFollowing = (currentUser: null | CurrentUser, userId: Id) =>
-  currentUser && currentUser.following.users.some(({ id }) => +id === +userId)
+  currentUser?.following?.users.some(({ id }) => +id === +userId) ?? false
 
 export function startFollowFlow(currentUser: CurrentUser, userId: Id) {
-  const followings = currentUser.following.users
+  const followings = currentUser.following?.users ?? []
   const userIndex = followings.findIndex(({ id }) => +id === +userId)
   const isFollowed = userIndex !== -1
 

--- a/src/ui/Profile/Info.svelte
+++ b/src/ui/Profile/Info.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import type { CurrentUser } from '@/ui/FollowButton/flow'
   import { queryUserLayouts } from '@/api/user/layouts'
   import { queryUserAddressWatchlists, queryUserWatchlists } from '@/api/user/watchlists'
   import FollowButton from '@/ui/FollowButton/svelte'
@@ -8,8 +7,8 @@
   import { CreationType } from './types'
   import { SANBASE_ORIGIN } from '@/utils/links'
 
-  export let user: SAN.Author & { name?: string }
-  export let currentUser: SAN.CurrentUser & CurrentUser
+  export let user: SAN.Author & { followers?: { count: number } }
+  export let currentUser: { id: string; following?: { users: { id: string }[] } } | null
   export let type: CreationType
 
   let creations: any[] = []
@@ -25,16 +24,16 @@
 
 <div class="info">
   <div class="row v-center justify">
-    <ProfileNames
-      {user}
-      feature={type}
-      followers={user && user.followers ? user.followers.count : undefined}
-    />
+    <ProfileNames {user} feature={type} followers={user.followers?.count} />
 
     {#if currentUser && +currentUser.id === +user.id}
-      <a href="{SANBASE_ORIGIN}/account" class="btn-1 mrg-xl mrg--l" on:click={window.__onLinkClick}
-        >Account settings</a
+      <a
+        href="{SANBASE_ORIGIN}/account"
+        class="btn-1 mrg-xl mrg--l"
+        on:click={window.__onLinkClick}
       >
+        Account settings
+      </a>
     {:else}
       <FollowButton {user} {currentUser} class="mrg-xl mrg--l" />
     {/if}

--- a/src/ui/Profile/Names.svelte
+++ b/src/ui/Profile/Names.svelte
@@ -3,12 +3,12 @@
 
   let className = ''
   export { className as class }
-  export let user: SAN.Author & { name?: string }
+  export let user: SAN.Author
   export let followers: number | undefined = undefined
   export let feature: string
 
   $: ({ username, email } = user)
-  $: subtitle = followers >= 0 ? `${followers} Followers` : email
+  $: subtitle = followers ? `${followers} Followers` : email
 </script>
 
 <Profile {user} {feature} source="profile_info_tooltip" class="txt-m {className}">


### PR DESCRIPTION
## Summary
1. Update `currentUser` prop in different components to require only used fields
2. Update `id` type in `SAN.Author` and `CurrentUserType` to `string` from `number`

## Notion card
https://www.notion.so/santiment/Current-user-context-refactor-2252a82d1361807093c8e45f593c4443?source=copy_link

