### PR TITLE
Fix/display custom plan

### DIFF
--- a/.storybook/mock/user.ts
+++ b/.storybook/mock/user.ts
@@ -154,7 +154,7 @@ export function mockUser(currentUser: CurrentUser) {
       else if (businessMax) name = SubscriptionPlan.BUSINESS_MAX.key
       else if (custom) name = SubscriptionPlan.CUSTOM.key
 
-      const id = name && checkIsBusinessPlan({ name }) ? Product.SanAPI.id : Product.Sanbase.id
+      const id = name && checkIsBusinessPlan(name) ? Product.SanAPI.id : Product.Sanbase.id
 
       subscriptions[0] = {
         status: trial ? 'TRIALING' : 'ACTIVE',

--- a/src/lib/ui/app/PaymentForm/flow.ts
+++ b/src/lib/ui/app/PaymentForm/flow.ts
@@ -134,7 +134,7 @@ export function usePaymentFlow() {
       return Promise.reject('paymentMethod is missing')
     }
 
-    const planDisplayName = getPlanName(plan)
+    const planDisplayName = getPlanName(plan.name)
     const isConsumerPlan = !subscriptionPlan.$.formatted?.isBusiness
     const isEligibleForSanbaseTrial = isConsumerPlan && customer.$.isEligibleForSanbaseTrial
 

--- a/src/lib/ui/app/PlanChangeDialog/PlanChangeDialog.svelte
+++ b/src/lib/ui/app/PlanChangeDialog/PlanChangeDialog.svelte
@@ -42,7 +42,7 @@
     if (!primarySubscription) return
     if (loading) return
 
-    const planDisplayName = getPlanName(newPlan)
+    const planDisplayName = getPlanName(newPlan.name)
     loading = true
     Controller.lock()
 

--- a/src/lib/ui/app/SubscriptionPlan/PlanButton.svelte
+++ b/src/lib/ui/app/SubscriptionPlan/PlanButton.svelte
@@ -140,7 +140,7 @@
     {...anonymousProps}
     data-type="get_business"
   >
-    Get {getPlanName(plan)}
+    Get {getPlanName(plan.name)}
   </Button>
 {:else if isConsumerPlan && (customer.$.isEligibleForSanbaseTrial || isAnonymous)}
   <Button

--- a/src/lib/ui/app/SubscriptionPlan/subscription.ts
+++ b/src/lib/ui/app/SubscriptionPlan/subscription.ts
@@ -101,7 +101,9 @@ export function getCustomerSubscriptionData(subscription: null | TSubscription) 
     } = subscription
 
     const isBusiness = checkIsBusinessPlan(plan)
-    const planName = plan.name
+    const planName = plan.name.startsWith(SubscriptionPlan.CUSTOM.key)
+      ? SubscriptionPlan.CUSTOM.key
+      : plan.name
     const trialDaysLeft = trialEnd ? calculateDaysTo(trialEnd) : null
 
     const isCustom = planName === SubscriptionPlan.CUSTOM.key
@@ -110,7 +112,7 @@ export function getCustomerSubscriptionData(subscription: null | TSubscription) 
     const isMax = isBusiness || planName === SubscriptionPlan.MAX.key
     const isProPlus = isBusiness || planName === SubscriptionPlan.PRO_PLUS.key
     const isPro = isProPlus || isMax || planName === SubscriptionPlan.PRO.key
-    const isFree = !isPro && !isMax && !isBusinessPro && !isBusinessMax
+    const isFree = !isPro && !isMax && !isBusinessPro && !isBusinessMax && !isCustom
 
     return {
       plan,
@@ -124,8 +126,8 @@ export function getCustomerSubscriptionData(subscription: null | TSubscription) 
       isFree,
       isCustom,
 
-      isBusinessSubscription: isBusiness,
-      isConsumerSubscription: isFree ? false : !isBusiness,
+      isBusinessSubscription: isBusiness || isCustom,
+      isConsumerSubscription: isFree ? false : !isBusiness && !isCustom,
 
       isCanceledSubscription: !!cancelAtPeriodEnd,
       isIncompleteSubscription: checkIsIncompleteSubscription(subscription),

--- a/src/lib/ui/app/SubscriptionPlan/subscription.ts
+++ b/src/lib/ui/app/SubscriptionPlan/subscription.ts
@@ -114,7 +114,7 @@ export function getCustomerSubscriptionData(subscription: null | TSubscription) 
 
     return {
       plan,
-      planName: getPlanName(plan),
+      planName: getPlanName(planName),
 
       isBusinessMax,
       isBusinessPro,

--- a/src/lib/ui/app/SubscriptionPlan/subscription.ts
+++ b/src/lib/ui/app/SubscriptionPlan/subscription.ts
@@ -60,7 +60,7 @@ export const getApiSubscription = (subscriptions: null | TSubscription[]) =>
 export function getPrimarySubscription(subscriptions: null | TSubscription[]) {
   const apiSubscription = getApiSubscription(subscriptions)
 
-  if (apiSubscription && checkIsBusinessPlan(apiSubscription.plan)) {
+  if (apiSubscription && checkIsBusinessPlan(apiSubscription.plan.name)) {
     return apiSubscription
   }
 
@@ -100,10 +100,10 @@ export function getCustomerSubscriptionData(subscription: null | TSubscription) 
       currentPeriodEnd = Date.now(),
     } = subscription
 
-    const isBusiness = checkIsBusinessPlan(plan)
     const planName = plan.name.startsWith(SubscriptionPlan.CUSTOM.key)
       ? SubscriptionPlan.CUSTOM.key
       : plan.name
+    const isBusiness = checkIsBusinessPlan(planName)
     const trialDaysLeft = trialEnd ? calculateDaysTo(trialEnd) : null
 
     const isCustom = planName === SubscriptionPlan.CUSTOM.key
@@ -126,8 +126,8 @@ export function getCustomerSubscriptionData(subscription: null | TSubscription) 
       isFree,
       isCustom,
 
-      isBusinessSubscription: isBusiness || isCustom,
-      isConsumerSubscription: isFree ? false : !isBusiness && !isCustom,
+      isBusinessSubscription: isBusiness,
+      isConsumerSubscription: isFree ? false : !isBusiness,
 
       isCanceledSubscription: !!cancelAtPeriodEnd,
       isIncompleteSubscription: checkIsIncompleteSubscription(subscription),

--- a/src/lib/ui/app/SubscriptionPlan/utils.ts
+++ b/src/lib/ui/app/SubscriptionPlan/utils.ts
@@ -12,8 +12,10 @@ export const checkIsBusinessPlan = (plan: null | Pick<TSubscriptionPlan, 'name'>
   plan ? BUSINESS_PLANS.has(plan.name) : false
 
 type TLooseRecord<T extends Record<string, unknown>> = T & Record<string, undefined | T[keyof T]>
-export const getPlanName = (plan: Pick<TSubscriptionPlan, 'name'>): string =>
-  (SubscriptionPlan as TLooseRecord<typeof SubscriptionPlan>)[plan.name]?.name || plan.name
+export const getPlanName = (planName: string): string => {
+  const subs: TLooseRecord<typeof SubscriptionPlan> = SubscriptionPlan
+  return subs[planName]?.name || planName
+}
 
 export function getFormattedBillingPlan(plan: TSubscriptionPlan) {
   const { name, amount, price } = getFormattedPlan(plan)
@@ -29,7 +31,7 @@ export function getFormattedPlan(
   monthlyPlan: TSubscriptionPlan,
   annualPlan?: null | TSubscriptionPlan,
 ) {
-  const name = getPlanName(monthlyPlan)
+  const name = getPlanName(monthlyPlan.name)
   const details = SubscriptionPlanDetails[monthlyPlan.name]
 
   return {

--- a/src/lib/ui/app/SubscriptionPlan/utils.ts
+++ b/src/lib/ui/app/SubscriptionPlan/utils.ts
@@ -8,8 +8,8 @@ export const checkIsSanbaseProduct = (product: Pick<TProduct, 'id'>) =>
 export const checkIsSanApiProduct = (product: Pick<TProduct, 'id'>) =>
   product.id === Product.SanAPI.id
 
-export const checkIsBusinessPlan = (plan: null | Pick<TSubscriptionPlan, 'name'>) =>
-  plan ? BUSINESS_PLANS.has(plan.name) : false
+export const checkIsBusinessPlan = (planName: string | undefined) =>
+  planName ? BUSINESS_PLANS.has(planName) : false
 
 type TLooseRecord<T extends Record<string, unknown>> = T & Record<string, undefined | T[keyof T]>
 export const getPlanName = (planName: string): string => {

--- a/src/stories/Design System - App UI/AccountDropdown/index.stories.ts
+++ b/src/stories/Design System - App UI/AccountDropdown/index.stories.ts
@@ -144,3 +144,18 @@ export const Enterprise: Story = {
     }),
   },
 }
+
+export const CustomEnterprise: Story = {
+  name: 'Custom Enterprise',
+
+  parameters: {
+    mockApi: () => ({
+      currentUser: {
+        plan: {
+          name: 'CUSTOM_SOME_PLAN',
+          monthly: true,
+        },
+      },
+    }),
+  },
+}


### PR DESCRIPTION
## Summary
1. Treat all plans starting from `CUSTOM` string as `CUSTOM`
2. Refactor `getPlanName` and `checkIsBusinessPlan` utility function to accept only plan name instead of whole plan object
