### PR TITLE
fix(plan) Fix display name of custom plan in subscription settings

### DIFF
--- a/src/stores/customer.ts
+++ b/src/stores/customer.ts
@@ -9,7 +9,7 @@ import {
   normalizeAnnualDiscount,
   Status,
 } from '@/utils/subscription'
-import { Plan, PlanName, checkIsBusinessPlan } from '@/utils/plans'
+import { Plan, checkIsBusinessPlan, getPlanName } from '@/utils/plans'
 import { QueryStore, setSessionValue } from './utils'
 import { BROWSER } from 'esm-env'
 
@@ -129,7 +129,7 @@ function getCustomerSubscriptionData(subscription: undefined | null | any) {
 
     isTrial: trialDaysLeft > 0 && status === Status.TRIALING,
     trialDaysLeft,
-    planName: PlanName[planName] || planName,
+    planName: getPlanName(planName),
     isCanceled: !!cancelAtPeriodEnd,
   }
 }

--- a/src/ui/PaymentDialog/PlanSelector.svelte
+++ b/src/ui/PaymentDialog/PlanSelector.svelte
@@ -3,13 +3,13 @@
   import Svg from '@/ui/Svg/svelte'
   import Tooltip from '@/ui/Tooltip'
   import {
-    PlanName,
     checkIsYearlyPlan,
     formatMonthlyPrice,
     Billing,
     getAlternativePlan,
     getSavedAmount,
     calculateYearDiscount,
+    getPlanName,
   } from '@/utils/plans'
 
   export let plans: SAN.Plan[]
@@ -75,7 +75,7 @@
             class:active={plan === option}
             on:click={() => select(option)}
           >
-            {isSinglePlan ? 'Bill' : PlanName[option.name]}
+            {isSinglePlan ? 'Bill' : getPlanName(option.name)}
             {option.interval === Billing.YEAR ? 'annual' : 'montly'} -
             <span class="txt-b">{formatMonthlyPrice(option)}/mo</span>
 

--- a/src/ui/PaymentDialog/index.svelte
+++ b/src/ui/PaymentDialog/index.svelte
@@ -1,6 +1,12 @@
 <script context="module" lang="ts">
   import { queryPlans, getCachedProducts, getBusinessPlans, getIndividualPlans } from '@/api/plans'
-  import { formatPrice, checkIsBusinessPlan, checkIsPlanWithPrice, Plan } from '@/utils/plans'
+  import {
+    formatPrice,
+    checkIsBusinessPlan,
+    checkIsPlanWithPrice,
+    Plan,
+    getPlanName,
+  } from '@/utils/plans'
   import { Preloader } from '@/utils/fn'
   import { stripe } from '@/stores/stripe'
   import { dialogs } from '@/ui/Dialog'
@@ -18,7 +24,6 @@
   import { onDestroy } from 'svelte'
   import Dialog from '@/ui/Dialog'
   import { DialogLock } from '@/ui/Dialog/dialogs'
-  import { PlanName } from '@/utils/plans'
   import { paymentCard$ } from '@/stores/paymentCard'
   import { getCustomer$Ctx } from '@/stores/customer'
   import { trackPaymentFormClosed, trackPaymentFormOpened } from '@/analytics/events/payment'
@@ -55,7 +60,7 @@
   $: isNotCanceled = !subscription?.cancelAtPeriodEnd
   // TODO: make customer data accesible via context
   $: ({ sanBalance, isEligibleForTrial, annualDiscount } = $customer$)
-  $: name = PlanName[plan.name] || plan.name
+  $: name = getPlanName(plan.name)
   $: price = name ? formatPrice(plan) : ''
 
   $: if (BROWSER) {

--- a/src/ui/PaymentDialog/utils.ts
+++ b/src/ui/PaymentDialog/utils.ts
@@ -1,7 +1,7 @@
 import { track, Tracker } from '@/analytics'
 import { trackTwitterPurchaseEvent, TwitterTrackActions } from '@/analytics/twitter'
 import { mutateSubscribe } from '@/api/plans'
-import { PlanName } from '@/utils/plans'
+import { getPlanName } from '@/utils/plans'
 import { notifications$ } from '@/ui/Notifications'
 import { paymentCard$ } from '@/stores/paymentCard'
 import {
@@ -62,8 +62,10 @@ function submitPayment(plan: SAN.Plan, discount: any, source: string, cardTokenI
 }
 
 export function createCardToken(
+  /* eslint-disable */
   stripe: stripe.Stripe,
   card: stripe.elements.Element,
+  /* eslint-enable */
   checkoutInfo: { [key: string]: any },
 ) {
   return stripe.createToken(card, checkoutInfo).then(({ token, error }) => {
@@ -76,8 +78,10 @@ export function createCardToken(
 export function buyPlan(
   customer$: SAN.CustomerStore,
   plan: SAN.Plan,
+  /* eslint-disable */
   stripe: stripe.Stripe,
   card: stripe.elements.Element,
+  /* eslint-enable */
   form: { [key: string]: any },
   source: string,
   savedCard?: SAN.PaymentCard,
@@ -118,7 +122,7 @@ export function buyPlan(
 export function onPaymentSuccess(data, source, customer$: SAN.CustomerStore, method?: string) {
   const { plan } = data
   const { name, amount } = plan
-  const title = PlanName[name] || name
+  const title = getPlanName(name)
 
   trackTwitterPurchaseEvent()
 

--- a/src/ui/Pricing/Comparison/Plan.svelte
+++ b/src/ui/Pricing/Comparison/Plan.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { formatMonthlyPrice, Plan, PlanName } from '@/utils/plans'
+  import { formatMonthlyPrice, getPlanName, Plan } from '@/utils/plans'
   import PlanButton from '../PlanButton.svelte'
 
   export let plan: SAN.Plan
@@ -12,7 +12,7 @@
 
 <div class="fluid">
   <h3 class="row v-center">
-    <span class="h4 txt-m">{PlanName[name]}</span>
+    <span class="h4 txt-m">{getPlanName(name)}</span>
 
     {#if discount && !isFreePlan}<span class="discount mrg-m mrg--l">50% Off</span>{/if}
 

--- a/src/ui/Pricing/Plan.svelte
+++ b/src/ui/Pricing/Plan.svelte
@@ -6,7 +6,8 @@
     formatPrice,
     checkIsBusinessPlan,
     Plan,
-    PlanName,
+    getIsCustomPlan,
+    getPlanName,
   } from '@/utils/plans'
   import { checkIsTrialSubscription } from '@/utils/subscription'
   import PlanButton from './PlanButton.svelte'
@@ -31,7 +32,7 @@
   $: isBusiness = checkIsBusinessPlan(monthPlan)
 
   $: isFreePlan = name.includes(Plan.FREE)
-  $: isCustomPlan = name.includes(Plan.CUSTOM)
+  $: isCustomPlan = getIsCustomPlan(name)
 
   $: ({ description, features } = PlanDescription[name])
 
@@ -43,7 +44,7 @@
 </script>
 
 <div class="plan txt-center relative {className}" class:isBusiness class:free={isFreePlan}>
-  <div class="name h4 txt-m c-accent">{PlanName[name]}</div>
+  <div class="name h4 txt-m c-accent">{getPlanName(name)}</div>
 
   {#if isTrialPlan}<div class="trial label">Your trial plan</div>{/if}
 

--- a/src/ui/Pricing/PlanButton.svelte
+++ b/src/ui/Pricing/PlanButton.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { getCustomer$Ctx } from '@/stores/customer'
-  import { Billing, Plan, checkIsBusinessPlan } from '@/utils/plans'
+  import { Billing, Plan, checkIsBusinessPlan, getIsCustomPlan } from '@/utils/plans'
   import { dataPreloader, showPaymentDialog } from '@/ui/PaymentDialog/index.svelte'
   import { showPlanChangeDialog } from './PlanChangeDialog.svelte'
   import { checkIsUpgrade, PLAN_BUTTON_CLICKED } from './utils'
@@ -17,7 +17,7 @@
 
   $: ({ id, name } = plan)
   $: isBusinessPlan = checkIsBusinessPlan(plan)
-  $: isCustomPlan = name === Plan.CUSTOM
+  $: isCustomPlan = getIsCustomPlan(name)
   $: isFreePlan = name === Plan.FREE
   $: isCurrentPlan = subscription ? subscription.plan.id === id : isFreePlan && isLoggedIn
   $: isUpgrade = checkIsUpgrade(plan, subscription)

--- a/src/ui/Pricing/PlanChangeDialog.svelte
+++ b/src/ui/Pricing/PlanChangeDialog.svelte
@@ -10,7 +10,7 @@
   import { DialogLock } from '@/ui/Dialog/dialogs'
   import Svg from '@/ui/Svg/svelte'
   import { getCustomer$Ctx } from '@/stores/customer'
-  import { Billing, formatPrice, PlanName } from '@/utils/plans'
+  import { Billing, formatPrice, getPlanName } from '@/utils/plans'
   import { getDateFormats } from '@/utils/dates'
   import { mutateUpdateSubscription, queryUpcomingInvoice } from '@/api/subscription'
   import { onPlanChangeError, onPlanChangeSuccess } from './utils'
@@ -26,12 +26,12 @@
   const { customer$ } = getCustomer$Ctx()
 
   const subscription = $customer$.subscription as SAN.Subscription
-  const newName = PlanName[plan.name] || plan.name
+  const newName = getPlanName(plan.name)
   const isNewBillingMonthly = plan.interval === Billing.MONTH
   const newBilling = isNewBillingMonthly ? 'Monthly' : 'Annual'
 
   const { currentPeriodEnd = Date.now(), plan: currentPlan } = subscription
-  const currentPlanName = PlanName[currentPlan.name] || currentPlan.name
+  const currentPlanName = getPlanName(currentPlan.name)
 
   function formatDate() {
     const { MMMM, DD, YYYY } = getDateFormats(new Date(currentPeriodEnd))

--- a/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/PlanCard.svelte
+++ b/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/PlanCard.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { SANBASE_ORIGIN } from '@/utils/links'
-  import { formatPrice, Plan, PlanName } from '@/utils/plans'
+  import { formatPrice, getIsCustomPlan, getPlanName } from '@/utils/plans'
   import { showPaymentDialog } from '@/ui/PaymentDialog/index.svelte'
   import Card from './Card.svelte'
 
@@ -15,7 +15,7 @@
   export let plans = [] as SAN.Plan[]
   export let description = ''
   export let onActionClick = (e) => {
-    if (plan.name === Plan.CUSTOM) {
+    if (getIsCustomPlan(plan.name)) {
       window.open('https://calendly.com/santiment-team/santiment-enterprise-plan-enquiry', '_blank')
       return
     }
@@ -34,7 +34,7 @@
   $: ({ billing, price } = getBillingPrice(plan))
 
   function getBillingPrice(plan: SAN.Plan) {
-    if (plan.name === Plan.CUSTOM)
+    if (getIsCustomPlan(plan.name))
       return {
         price: 'Custom',
         billing: 'Based on your needs',
@@ -54,7 +54,7 @@
   {discount}
   {shouldHideBillingInfo}
   {onActionClick}
-  action={plan.name === Plan.CUSTOM
+  action={getIsCustomPlan(plan.name)
     ? 'Let’s talk!'
     : discount
     ? `Pay now ${discount}% Off`
@@ -64,7 +64,7 @@
     ? 'Upgrade'
     : action}
   disabled={action === 'Default plan'}
-  title={PlanName[name] + (isTrial ? ' Trial' : '')}
+  title={getPlanName(name) + (isTrial ? ' Trial' : '')}
   label={discount ? 'Special offer' : label}
   badge={discount ? `${discount}% Off` : badge}
   badgeIcon={discount ? null : badgeIcon}

--- a/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/UserPlanCard.svelte
+++ b/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/UserPlanCard.svelte
@@ -19,6 +19,7 @@
   $: isPaidPlan = plan?.name !== Plan.FREE
   $: trialDaysLeft = subscription && getTrialDaysLeft(subscription)
   $: isCancelled = Boolean(subscription && subscription.cancelAtPeriodEnd)
+  $: console.log({ plan })
 
   function formatDate(date) {
     const { DD, MMMM, YYYY } = getDateFormats(date)

--- a/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/suggestions.ts
+++ b/src/ui/Pricing/SubscriptionSettings/SubscriptionCard/suggestions.ts
@@ -94,7 +94,9 @@ export function getBusinessSuggestions(userPlan: UserPlan | null): PlanSuggestio
     return allBusinessSuggestions.slice(1)
   }
 
-  const planIndex = Array.from(BUSINESS_PLANS).indexOf(userPlan.name as Plan)
+  const planName = userPlan.name.startsWith('CUSTOM') ? Plan.CUSTOM : (userPlan.name as Plan)
+
+  const planIndex = Array.from(BUSINESS_PLANS).indexOf(planName)
   if (planIndex === -1) return allBusinessSuggestions
   if (planIndex >= BUSINESS_PLANS.size - 1) return []
 

--- a/src/ui/Pricing/SubscriptionSettings/index.svelte
+++ b/src/ui/Pricing/SubscriptionSettings/index.svelte
@@ -7,7 +7,7 @@
   import { getBusinessPlans, getIndividualPlans, queryPlans, queryPppSettings } from '@/api/plans'
   import { getCustomer$Ctx } from '@/stores/customer'
   import { paymentCard$ } from '@/stores/paymentCard'
-  import { Billing, Plan, PlanName, ProductId } from '@/utils/plans'
+  import { Billing, getIsCustomPlan, getPlanName, Plan, ProductId } from '@/utils/plans'
   import { checkIsActiveSubscription } from '@/utils/subscription'
   import Setting from './Setting.svelte'
   import UserPlanCard from './SubscriptionCard/UserPlanCard.svelte'
@@ -68,7 +68,7 @@
     plans = individualPlans
       .concat(businessPlans)
       .sort((a, b) =>
-        a.name === Plan.CUSTOM ? 1 : b.name === Plan.CUSTOM ? -1 : a.amount - b.amount,
+        getIsCustomPlan(a.name) ? 1 : getIsCustomPlan(b.name) ? -1 : a.amount - b.amount,
       )
   }
 
@@ -106,7 +106,7 @@
       />
 
       <PlanSuggestions suggestions={individualSuggestions} {plans} {isEligibleForTrial}>
-        <FullAccessCard currentPlanName={PlanName[plan.name]} />
+        <FullAccessCard currentPlanName={getPlanName(plan.name)} />
       </PlanSuggestions>
     </plans-section>
 

--- a/src/utils/plans.ts
+++ b/src/utils/plans.ts
@@ -34,10 +34,14 @@ export enum Plan {
   CUSTOM = 'CUSTOM',
 }
 
+export function getIsCustomPlan(planName: string): boolean {
+  return planName.startsWith(Plan.CUSTOM)
+}
+
 export const INDIVIDUAL_PLANS = new Set([Plan.FREE, Plan.PRO, Plan.MAX])
 export const BUSINESS_PLANS = new Set([Plan.BUSINESS_PRO, Plan.BUSINESS_MAX, Plan.CUSTOM])
 
-export const PlanName = {
+const PlanName = {
   [Plan.PRO_PLUS]: 'Pro+',
 
   [Plan.FREE]: 'FREE',
@@ -48,6 +52,11 @@ export const PlanName = {
   [Plan.BUSINESS_MAX]: 'Business Max',
   [Plan.CUSTOM]: 'Enterprise',
 } as const
+
+export function getPlanName(planName: string) {
+  const adaptedPlanName = getIsCustomPlan(planName) ? Plan.CUSTOM : planName
+  return PlanName[adaptedPlanName] ?? planName
+}
 
 export enum Billing {
   MONTH = 'month',
@@ -61,7 +70,10 @@ export enum PlanType {
 
 export const checkIsIndividualPlan = ({ name }: { name: string }) =>
   INDIVIDUAL_PLANS.has(name as Plan)
-export const checkIsBusinessPlan = ({ name }: { name: string }) => BUSINESS_PLANS.has(name as Plan)
+export const checkIsBusinessPlan = ({ name }: { name: string }) => {
+  const planName = getIsCustomPlan(name) ? Plan.CUSTOM : (name as Plan)
+  return BUSINESS_PLANS.has(planName)
+}
 
 export const checkIsPlanWithPrice = ({ amount }: Pick<SAN.Plan, 'amount'>) => amount > 0
 

--- a/src/utils/subscription.ts
+++ b/src/utils/subscription.ts
@@ -1,7 +1,12 @@
 import type { CustomerData } from '@/stores/user'
 
 import { ONE_DAY_IN_MS } from './dates'
-import { PlanName, checkIsSanApiProduct, checkIsSanbaseProduct, checkIsYearlyPlan } from './plans'
+import {
+  checkIsSanApiProduct,
+  checkIsSanbaseProduct,
+  checkIsYearlyPlan,
+  getPlanName,
+} from './plans'
 
 export enum Status {
   ACTIVE = 'ACTIVE',
@@ -54,7 +59,7 @@ export function getUserSubscriptionInfo(
   const annualDiscountPercent = annualDiscount?.isEligible && annualDiscount.discount?.percentOff
   const discountExpireAt = annualDiscount?.isEligible && annualDiscount.discount?.expireAt
   const subscriptionPlan = subscription?.plan.name
-  const userPlanName = PlanName[subscriptionPlan] || subscriptionPlan
+  const userPlanName = getPlanName(subscriptionPlan)
   const trialDaysLeft = subscription?.trialEnd ? calculateTrialDaysLeft(subscription.trialEnd) : 0
 
   return {

--- a/stories/Subscription/SubscriptionSettings/index.stories.ts
+++ b/stories/Subscription/SubscriptionSettings/index.stories.ts
@@ -173,3 +173,19 @@ export const BusinessProYearNoCard: Story = {
     }),
   },
 }
+
+export const CustomEnterprise: Story = {
+  parameters: {
+    mockApi: () => ({
+      ...mockPlans,
+      ...pppMock,
+      savedCard: false,
+      currentUser: {
+        plan: {
+          name: 'CUSTOM_BUSINESS_PRO_MAX_ULTRA_3M',
+          yearly: true,
+        },
+      },
+    }),
+  },
+}


### PR DESCRIPTION
## Summary

Handle properly plans starting with `CUSTOM`

## Notion card
https://www.notion.so/santiment/Fix-displayed-name-for-CUSTOM-plans-22a2a82d13618013959fe7e227651604?source=copy_link