### PR TITLE
Fix/custom plan retrieving

### DIFF
--- a/src/lib/ui/app/SubscriptionPlan/subscription.ts
+++ b/src/lib/ui/app/SubscriptionPlan/subscription.ts
@@ -1,6 +1,9 @@
 import type { TSubscriptionPlan } from '$ui/app/SubscriptionPlan/types.js'
 
 import { calculateDaysTo } from '$lib/utils/dates/index.js'
+
+import { checkIsCustomPlan } from './utils.js'
+
 import { SubscriptionPlan } from '$ui/app/SubscriptionPlan/plans.js'
 import {
   checkIsBusinessPlan,
@@ -100,23 +103,20 @@ export function getCustomerSubscriptionData(subscription: null | TSubscription) 
       currentPeriodEnd = Date.now(),
     } = subscription
 
-    const planName = plan.name.startsWith(SubscriptionPlan.CUSTOM.key)
-      ? SubscriptionPlan.CUSTOM.key
-      : plan.name
-    const isBusiness = checkIsBusinessPlan(planName)
+    const isBusiness = checkIsBusinessPlan(plan.name)
     const trialDaysLeft = trialEnd ? calculateDaysTo(trialEnd) : null
 
-    const isCustom = planName === SubscriptionPlan.CUSTOM.key
-    const isBusinessMax = isBusiness && planName === SubscriptionPlan.BUSINESS_MAX.key
-    const isBusinessPro = isBusinessMax || planName === SubscriptionPlan.BUSINESS_PRO.key
-    const isMax = isBusiness || planName === SubscriptionPlan.MAX.key
-    const isProPlus = isBusiness || planName === SubscriptionPlan.PRO_PLUS.key
-    const isPro = isProPlus || isMax || planName === SubscriptionPlan.PRO.key
+    const isCustom = checkIsCustomPlan(plan.name)
+    const isBusinessMax = isBusiness && plan.name === SubscriptionPlan.BUSINESS_MAX.key
+    const isBusinessPro = isBusinessMax || plan.name === SubscriptionPlan.BUSINESS_PRO.key
+    const isMax = isBusiness || plan.name === SubscriptionPlan.MAX.key
+    const isProPlus = isBusiness || plan.name === SubscriptionPlan.PRO_PLUS.key
+    const isPro = isProPlus || isMax || plan.name === SubscriptionPlan.PRO.key
     const isFree = !isPro && !isMax && !isBusinessPro && !isBusinessMax && !isCustom
 
     return {
       plan,
-      planName: getPlanName(planName),
+      planName: getPlanName(plan.name),
 
       isBusinessMax,
       isBusinessPro,

--- a/src/lib/ui/app/SubscriptionPlan/utils.ts
+++ b/src/lib/ui/app/SubscriptionPlan/utils.ts
@@ -2,19 +2,28 @@ import type { TProduct, TSubscriptionPlan } from './types.js'
 
 import { BUSINESS_PLANS, Product, SubscriptionPlan, SubscriptionPlanDetails } from './plans.js'
 
+export const checkIsCustomPlan = (planName: string) =>
+  planName.startsWith(SubscriptionPlan.CUSTOM.key)
+
 export const checkIsSanbaseProduct = (product: Pick<TProduct, 'id'>) =>
   product.id === Product.Sanbase.id
 
 export const checkIsSanApiProduct = (product: Pick<TProduct, 'id'>) =>
   product.id === Product.SanAPI.id
 
-export const checkIsBusinessPlan = (planName: string | undefined) =>
-  planName ? BUSINESS_PLANS.has(planName) : false
+export const checkIsBusinessPlan = (planName: string | undefined) => {
+  if (!planName) return false
+
+  const plan = checkIsCustomPlan(planName) ? SubscriptionPlan.CUSTOM.key : planName
+  return BUSINESS_PLANS.has(plan)
+}
 
 type TLooseRecord<T extends Record<string, unknown>> = T & Record<string, undefined | T[keyof T]>
 export const getPlanName = (planName: string): string => {
   const subs: TLooseRecord<typeof SubscriptionPlan> = SubscriptionPlan
-  return subs[planName]?.name || planName
+  const plan = checkIsCustomPlan(planName) ? SubscriptionPlan.CUSTOM.key : planName
+
+  return subs[plan]?.name || planName
 }
 
 export function getFormattedBillingPlan(plan: TSubscriptionPlan) {

--- a/src/stories/Design System - App UI/AccountDropdown/index.stories.ts
+++ b/src/stories/Design System - App UI/AccountDropdown/index.stories.ts
@@ -152,7 +152,7 @@ export const CustomEnterprise: Story = {
     mockApi: () => ({
       currentUser: {
         plan: {
-          name: 'CUSTOM_SOME_PLAN',
+          name: 'CUSTOM_BUSINESS_MAX_PRO_ULTRA_3M',
           monthly: true,
         },
       },

--- a/src/stories/Design System - App UI/AccountStatus/index.stories.ts
+++ b/src/stories/Design System - App UI/AccountStatus/index.stories.ts
@@ -106,3 +106,14 @@ export const Enterprise: Story = {
     }),
   },
 }
+
+export const CustomEnterprise: Story = {
+  name: 'Custom Enterprise',
+  parameters: {
+    mockApi: () => ({
+      currentUser: {
+        plan: { name: 'CUSTOM_BUSINESS_MAX_PRO_ULTRA_3M', yearly: true },
+      },
+    }),
+  },
+}


### PR DESCRIPTION
## Summary
Fix `primarySubscription` retrieving

## Notion card
https://www.notion.so/santiment/Fix-displayed-name-for-CUSTOM-plans-22a2a82d13618013959fe7e227651604?source=copy_link