### PR TITLE
Feat/table

### DIFF
--- a/src/lib/ui/core/Table/DataTable/DataTable.svelte
+++ b/src/lib/ui/core/Table/DataTable/DataTable.svelte
@@ -1,0 +1,49 @@
+<script
+  lang="ts"
+  generics="GItem extends Record<string, unknown>, GColumn extends BaseTableColumn<GItem>"
+>
+  import type { BaseTableColumn } from './types.js'
+
+  import Table from '../Table.svelte'
+  import TableBody from '../TableBody.svelte'
+  import TableCell from '../TableCell.svelte'
+  import TableHead from '../TableHead.svelte'
+  import TableHeader from '../TableHeader.svelte'
+  import TableRow from '../TableRow.svelte'
+
+  type TProps = {
+    items: GItem[]
+    columns: GColumn[]
+  }
+
+  const { items, columns }: TProps = $props()
+</script>
+
+<Table>
+  <TableHeader>
+    <TableRow>
+      {#each columns as { title, Head, class: className }}
+        {#if Head}
+          <Head />
+        {:else}
+          <TableHead class={className}>{title}</TableHead>
+        {/if}
+      {/each}
+    </TableRow>
+  </TableHeader>
+  <TableBody>
+    {#each items as item, i}
+      <TableRow>
+        {#each columns as column}
+          {#if column.Cell}
+            <column.Cell {item} />
+          {:else}
+            <TableCell class={column.class}>
+              {column.format(item, i)}
+            </TableCell>
+          {/if}
+        {/each}
+      </TableRow>
+    {/each}
+  </TableBody>
+</Table>

--- a/src/lib/ui/core/Table/DataTable/DataTable.svelte
+++ b/src/lib/ui/core/Table/DataTable/DataTable.svelte
@@ -14,14 +14,28 @@
   type TProps = {
     items: GItem[]
     columns: GColumn[]
+
+    class?: string
+    headerClass?: string
+    bodyClass?: string
+    headerRowClass?: string
+    bodyRowClass?: string
   }
 
-  const { items, columns }: TProps = $props()
+  const {
+    items,
+    columns,
+    class: className,
+    headerClass,
+    bodyClass,
+    headerRowClass,
+    bodyRowClass,
+  }: TProps = $props()
 </script>
 
-<Table>
-  <TableHeader>
-    <TableRow>
+<Table class={className}>
+  <TableHeader class={headerClass}>
+    <TableRow class={headerRowClass}>
       {#each columns as { title, Head, class: className }}
         {#if Head}
           <Head />
@@ -31,9 +45,9 @@
       {/each}
     </TableRow>
   </TableHeader>
-  <TableBody>
+  <TableBody class={bodyClass}>
     {#each items as item, i}
-      <TableRow>
+      <TableRow class={bodyRowClass}>
         {#each columns as column}
           {#if column.Cell}
             <column.Cell {item} />

--- a/src/lib/ui/core/Table/DataTable/types.ts
+++ b/src/lib/ui/core/Table/DataTable/types.ts
@@ -1,0 +1,25 @@
+import type { Component } from 'svelte'
+
+// TODO: Maybe it's not worth it to use union for format/Cell and title/Head options
+export type BaseTableColumn<GItem extends Record<string, unknown>> = {
+  class?: string
+} & (
+  | {
+      Cell: Component<{ item: GItem }>
+      format?: undefined
+    }
+  | {
+      Cell?: undefined
+      format: (item: GItem, index: number) => string | number
+    }
+) &
+  (
+    | {
+        title: string
+        Head?: undefined
+      }
+    | {
+        title?: undefined
+        Head: Component
+      }
+  )

--- a/src/lib/ui/core/Table/Table.svelte
+++ b/src/lib/ui/core/Table/Table.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+  import type { HTMLTableAttributes } from 'svelte/elements'
+
+  import { cn } from '$ui/utils/index.js'
+
+  type TProps = {
+    class?: string
+    children: Snippet
+  } & HTMLTableAttributes
+
+  const { class: className, children, ...props }: TProps = $props()
+</script>
+
+<table class={cn('relative w-full border-spacing-0 text-left', className)} {...props}>
+  {@render children()}
+</table>

--- a/src/lib/ui/core/Table/TableBody.svelte
+++ b/src/lib/ui/core/Table/TableBody.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+  import type { HTMLAttributes } from 'svelte/elements'
+
+  import { cn } from '$ui/utils/index.js'
+
+  type TProps = {
+    class?: string
+    children: Snippet
+  } & HTMLAttributes<HTMLTableSectionElement>
+
+  const { class: className, children, ...props }: TProps = $props()
+</script>
+
+<tbody class={cn('', className)} {...props}>
+  {@render children()}
+</tbody>

--- a/src/lib/ui/core/Table/TableCell.svelte
+++ b/src/lib/ui/core/Table/TableCell.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+  import type { HTMLTdAttributes } from 'svelte/elements'
+
+  import { cn } from '$ui/utils/index.js'
+
+  type TProps = {
+    class?: string
+    children: Snippet
+  } & HTMLTdAttributes
+
+  const { class: className, children, ...props }: TProps = $props()
+</script>
+
+<td
+  class={cn(
+    'overflow-hidden text-ellipsis whitespace-nowrap px-2 group-hover:bg-athens',
+    className,
+  )}
+  {...props}
+>
+  {@render children()}
+</td>

--- a/src/lib/ui/core/Table/TableHead.svelte
+++ b/src/lib/ui/core/Table/TableHead.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+  import type { HTMLThAttributes } from 'svelte/elements'
+
+  import { cn } from '$ui/utils/index.js'
+
+  type TProps = {
+    class?: string
+    children: Snippet
+  } & HTMLThAttributes
+
+  const { class: className, children, ...props }: TProps = $props()
+</script>
+
+<th
+  class={cn(
+    'whitespace-nowrap border-b bg-athens px-[15px] py-[5px] font-medium text-casper',
+    className,
+  )}
+  {...props}
+>
+  {@render children()}
+</th>

--- a/src/lib/ui/core/Table/TableHeader.svelte
+++ b/src/lib/ui/core/Table/TableHeader.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+  import type { HTMLAttributes } from 'svelte/elements'
+
+  import { cn } from '$ui/utils/index.js'
+
+  type TProps = {
+    class?: string
+    children: Snippet
+  } & HTMLAttributes<HTMLTableSectionElement>
+
+  const { class: className, children, ...props }: TProps = $props()
+</script>
+
+<thead class={cn('', className)} {...props}>
+  {@render children()}
+</thead>

--- a/src/lib/ui/core/Table/TableHeader.svelte
+++ b/src/lib/ui/core/Table/TableHeader.svelte
@@ -6,12 +6,13 @@
 
   type TProps = {
     class?: string
+    sticky?: boolean
     children: Snippet
   } & HTMLAttributes<HTMLTableSectionElement>
 
-  const { class: className, children, ...props }: TProps = $props()
+  const { class: className, children, sticky = false, ...props }: TProps = $props()
 </script>
 
-<thead class={cn('', className)} {...props}>
+<thead class={cn('', sticky && 'sticky top-0', className)} {...props}>
   {@render children()}
 </thead>

--- a/src/lib/ui/core/Table/TableRow.svelte
+++ b/src/lib/ui/core/Table/TableRow.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+  import type { HTMLAttributes } from 'svelte/elements'
+
+  import { cn } from '$ui/utils/index.js'
+
+  type TProps = {
+    class?: string
+    children: Snippet
+  } & HTMLAttributes<HTMLTableRowElement>
+
+  const { class: className, children, ...props }: TProps = $props()
+</script>
+
+<tr class={cn('group', className)} {...props}>
+  {@render children()}
+</tr>

--- a/src/lib/ui/core/Table/index.ts
+++ b/src/lib/ui/core/Table/index.ts
@@ -1,0 +1,6 @@
+export { default as Table } from './Table.svelte'
+export { default as TableHeader } from './TableHeader.svelte'
+export { default as TableHead } from './TableHead.svelte'
+export { default as TableBody } from './TableBody.svelte'
+export { default as TableRow } from './TableRow.svelte'
+export { default as TableCell } from './TableCell.svelte'

--- a/src/lib/ui/core/Table/index.ts
+++ b/src/lib/ui/core/Table/index.ts
@@ -4,3 +4,5 @@ export { default as TableHead } from './TableHead.svelte'
 export { default as TableBody } from './TableBody.svelte'
 export { default as TableRow } from './TableRow.svelte'
 export { default as TableCell } from './TableCell.svelte'
+
+export { default as DataTable } from './DataTable/DataTable.svelte'

--- a/src/stories/Design System - Core UI/Table/DataTable/CustomCell.svelte
+++ b/src/stories/Design System - Core UI/Table/DataTable/CustomCell.svelte
@@ -1,0 +1,16 @@
+<script lang="ts">
+  import { TableCell } from '$ui/core/Table/index.js'
+  import type { Item } from '../utils.js'
+
+  type TProps = {
+    item: Item
+  }
+
+  const { item }: TProps = $props()
+</script>
+
+<TableCell>
+  <div class="font-bold text-red">
+    {item.volume}
+  </div>
+</TableCell>

--- a/src/stories/Design System - Core UI/Table/DataTable/DataTable.svelte
+++ b/src/stories/Design System - Core UI/Table/DataTable/DataTable.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+  import { DataTable } from '$ui/core/Table/index.js'
+  import { generateItems } from '../utils.js'
+  import { columns } from './columns.js'
+
+  const items = generateItems(10)
+</script>
+
+<main class="flex h-screen items-start justify-center px-10 py-5">
+  <DataTable {items} {columns} />
+</main>

--- a/src/stories/Design System - Core UI/Table/DataTable/columns.ts
+++ b/src/stories/Design System - Core UI/Table/DataTable/columns.ts
@@ -1,0 +1,23 @@
+import { usdFormatter } from '$ui/app/Chart/ctx/formatters.js'
+import type { BaseTableColumn } from '$ui/core/Table/DataTable/types.js'
+import CustomCell from './CustomCell.svelte'
+import type { Item } from '../utils.js'
+
+export const columns: BaseTableColumn<Item>[] = [
+  {
+    title: '#',
+    format: (_, index) => index + 1,
+  },
+  {
+    title: 'Title',
+    format: ({ title }) => title,
+  },
+  {
+    title: 'Price',
+    format: ({ value }) => usdFormatter(value),
+  },
+  {
+    title: 'Tokens',
+    Cell: CustomCell,
+  },
+]

--- a/src/stories/Design System - Core UI/Table/DataTable/columns.ts
+++ b/src/stories/Design System - Core UI/Table/DataTable/columns.ts
@@ -14,7 +14,7 @@ export const columns: BaseTableColumn<Item>[] = [
   },
   {
     title: 'Price',
-    format: ({ value }) => usdFormatter(value),
+    format: ({ price }) => usdFormatter(price),
   },
   {
     title: 'Tokens',

--- a/src/stories/Design System - Core UI/Table/DataTable/index.ts
+++ b/src/stories/Design System - Core UI/Table/DataTable/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DataTable.svelte'

--- a/src/stories/Design System - Core UI/Table/index.stories.ts
+++ b/src/stories/Design System - Core UI/Table/index.stories.ts
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/svelte'
+import type { ComponentType } from 'svelte'
 
 import component from './index.svelte'
+import DataTableComponent from './DataTable/index.js'
 
 const meta = {
   component,
@@ -13,3 +15,7 @@ type Story = StoryObj<typeof meta>
 export default meta
 
 export const SimpleTable: Story = {}
+
+export const DataTable: StoryObj<typeof DataTableComponent> = {
+  render: () => ({ Component: DataTableComponent as unknown as ComponentType }),
+}

--- a/src/stories/Design System - Core UI/Table/index.stories.ts
+++ b/src/stories/Design System - Core UI/Table/index.stories.ts
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/svelte'
+
+import component from './index.svelte'
+
+const meta = {
+  component,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<component>
+type Story = StoryObj<typeof meta>
+
+export default meta
+
+export const SimpleTable: Story = {}

--- a/src/stories/Design System - Core UI/Table/index.svelte
+++ b/src/stories/Design System - Core UI/Table/index.svelte
@@ -4,12 +4,12 @@
   import TableHead from '$ui/core/Table/TableHead.svelte'
   import { generateItems, type Item } from './utils.js'
 
-  const DATA: Item[] = generateItems(10)
+  const DATA: Item[] = generateItems(100)
 </script>
 
-<div class="flex h-screen items-start justify-center px-10 py-5">
+<div class="flex items-start justify-center px-10 py-5">
   <Table>
-    <TableHeader>
+    <TableHeader sticky>
       <TableRow>
         <TableHead>#</TableHead>
         <TableHead>Name</TableHead>

--- a/src/stories/Design System - Core UI/Table/index.svelte
+++ b/src/stories/Design System - Core UI/Table/index.svelte
@@ -1,0 +1,41 @@
+<script lang="ts">
+  import { usdFormatter } from '$ui/app/Chart/ctx/formatters.js'
+  import { Table, TableBody, TableCell, TableHeader, TableRow } from '$ui/core/Table/index.js'
+  import TableHead from '$ui/core/Table/TableHead.svelte'
+
+  type TData = {
+    name: string
+    price: number
+    count: number
+  }
+
+  const DATA: TData[] = [
+    { name: 'bitcoin', price: 100_000, count: 10 },
+    { name: 'ethereum', price: 3000, count: 200 },
+    { name: 'tether', price: 1, count: 123 },
+    { name: 'doge', price: 0.15, count: 14310 },
+  ]
+</script>
+
+<div class="flex h-screen items-start justify-center px-10 py-5">
+  <Table>
+    <TableHeader>
+      <TableRow>
+        <TableHead>#</TableHead>
+        <TableHead>Name</TableHead>
+        <TableHead>Price</TableHead>
+        <TableHead>Count</TableHead>
+      </TableRow>
+    </TableHeader>
+    <TableBody>
+      {#each DATA as { name, price, count }, i}
+        <TableRow>
+          <TableCell>{i + 1}</TableCell>
+          <TableCell>{name}</TableCell>
+          <TableCell>{usdFormatter(price)}</TableCell>
+          <TableCell>{count}</TableCell>
+        </TableRow>
+      {/each}
+    </TableBody>
+  </Table>
+</div>

--- a/src/stories/Design System - Core UI/Table/index.svelte
+++ b/src/stories/Design System - Core UI/Table/index.svelte
@@ -2,19 +2,9 @@
   import { usdFormatter } from '$ui/app/Chart/ctx/formatters.js'
   import { Table, TableBody, TableCell, TableHeader, TableRow } from '$ui/core/Table/index.js'
   import TableHead from '$ui/core/Table/TableHead.svelte'
+  import { generateItems, type Item } from './utils.js'
 
-  type TData = {
-    name: string
-    price: number
-    count: number
-  }
-
-  const DATA: TData[] = [
-    { name: 'bitcoin', price: 100_000, count: 10 },
-    { name: 'ethereum', price: 3000, count: 200 },
-    { name: 'tether', price: 1, count: 123 },
-    { name: 'doge', price: 0.15, count: 14310 },
-  ]
+  const DATA: Item[] = generateItems(10)
 </script>
 
 <div class="flex h-screen items-start justify-center px-10 py-5">
@@ -28,12 +18,12 @@
       </TableRow>
     </TableHeader>
     <TableBody>
-      {#each DATA as { name, price, count }, i}
+      {#each DATA as { id, title, price, volume }, i}
         <TableRow>
-          <TableCell>{i + 1}</TableCell>
-          <TableCell>{name}</TableCell>
+          <TableCell>{id + 1}</TableCell>
+          <TableCell>{title}</TableCell>
           <TableCell>{usdFormatter(price)}</TableCell>
-          <TableCell>{count}</TableCell>
+          <TableCell>{volume}</TableCell>
         </TableRow>
       {/each}
     </TableBody>

--- a/src/stories/Design System - Core UI/Table/utils.ts
+++ b/src/stories/Design System - Core UI/Table/utils.ts
@@ -1,0 +1,21 @@
+export type Item = {
+  id: number
+  title: string
+  value: number
+  volume: number
+}
+
+function randomNum(min: number, max: number, step: number) {
+  return min + Math.floor((Math.random() * (max - min + 1)) / step) * step
+}
+
+export function generateItems(count: number) {
+  return Array<void>(count)
+    .fill(undefined)
+    .map<Item>((_, i) => ({
+      id: i,
+      title: (Math.random() + 1).toString(36).substring(7),
+      value: randomNum(50, 2000, 50),
+      volume: randomNum(10, 5000, 10),
+    }))
+}

--- a/src/stories/Design System - Core UI/Table/utils.ts
+++ b/src/stories/Design System - Core UI/Table/utils.ts
@@ -1,21 +1,22 @@
 export type Item = {
   id: number
   title: string
-  value: number
+  price: number
   volume: number
 }
 
-function randomNum(min: number, max: number, step: number) {
-  return min + Math.floor((Math.random() * (max - min + 1)) / step) * step
-}
+const randomNum = (min: number, max: number, step: number) =>
+  min + Math.floor((Math.random() * (max - min + 1)) / step) * step
+
+const randomString = () => (Math.random() + 1).toString(36).substring(7)
 
 export function generateItems(count: number) {
   return Array<void>(count)
     .fill(undefined)
     .map<Item>((_, i) => ({
       id: i,
-      title: (Math.random() + 1).toString(36).substring(7),
-      value: randomNum(50, 2000, 50),
+      title: randomString(),
+      price: randomNum(50, 2000, 50),
       volume: randomNum(10, 5000, 10),
     }))
 }


### PR DESCRIPTION
## Summary
Add basic table parts and combined `DataTable` component. No filtering, sorting or pagination for now

## Notion card
https://www.notion.so/santiment/Migrate-Table-from-san-queries-to-webkit-next-2332a82d1361804890bfcc72fdef7a52?source=copy_link

## Screenshots
<img width="2992" height="1310" alt="image" src="https://github.com/user-attachments/assets/7066d497-1076-40d9-93b3-5597681cdb2a" />

<img width="2992" height="1310" alt="image" src="https://github.com/user-attachments/assets/fdc6665a-9a77-4481-8531-080b05449d42" />
