### PR TITLE
Fix/partial alerts

### DIFF
--- a/src/lib/ui/app/Alerts/Dialog/AlertFormScreen.svelte
+++ b/src/lib/ui/app/Alerts/Dialog/AlertFormScreen.svelte
@@ -12,7 +12,7 @@
 
   type TProps = {
     schema: TAlertSchemaUnion
-    apiAlert?: null | TApiAlert
+    apiAlert?: null | Partial<TApiAlert>
     resetCategory: () => void
     close: () => void
   }

--- a/src/lib/ui/app/Alerts/Dialog/AlertFormScreen.svelte
+++ b/src/lib/ui/app/Alerts/Dialog/AlertFormScreen.svelte
@@ -26,9 +26,9 @@
   async function onAlertCreate() {
     try {
       loading = true
-      const reducedAlert = createApiAlert()
+      const reducedAlert = { ...createApiAlert(), id: alert?.id ?? null }
 
-      await mutateSaveAlert(Query)({ ...reducedAlert, id: alert?.id ?? null })
+      await mutateSaveAlert(Query)(reducedAlert)
 
       close()
     } catch (e) {
@@ -40,9 +40,15 @@
   }
 
   function createApiAlert() {
-    return steps.reduce((acc, step) => step.reduceToApi(acc, $state.snapshot(step.state.$$)), {
-      settings: {},
-    }) as Omit<TApiAlert, 'id'>
+    return steps.reduce(
+      (acc, step) => {
+        const state = $state.snapshot(step.state.$$) as typeof step.state.$$
+        return step.reduceToApi(acc, state as UnionToIntersection<typeof state>)
+      },
+      {
+        settings: {},
+      },
+    ) as Omit<TApiAlert, 'id'>
   }
 </script>
 
@@ -88,6 +94,6 @@
       <h3 class="text-lg font-medium">{selectedStep.$.ui.label}</h3>
     </div>
 
-    <selectedStep.$.ui.Form step={selectedStep.$}></selectedStep.$.ui.Form>
+    <selectedStep.$.ui.Form state={selectedStep.$.state}></selectedStep.$.ui.Form>
   </main>
 </section>

--- a/src/lib/ui/app/Alerts/Dialog/AlertFormScreen.svelte
+++ b/src/lib/ui/app/Alerts/Dialog/AlertFormScreen.svelte
@@ -12,13 +12,13 @@
 
   type TProps = {
     schema: TAlertSchemaUnion
-    apiAlert?: null | Partial<TApiAlert>
+    alert?: null | Partial<TApiAlert>
     resetCategory: () => void
     close: () => void
   }
-  let { schema, apiAlert, resetCategory, close }: TProps = $props()
+  let { schema, alert, resetCategory, close }: TProps = $props()
 
-  const { steps, selectedStep, isAlertValid } = useAlertFormCtx({ schema, apiAlert })
+  const { steps, selectedStep, isAlertValid } = useAlertFormCtx({ schema, alert })
 
   let loading = $state(false)
 
@@ -28,7 +28,7 @@
       loading = true
       const reducedAlert = createApiAlert()
 
-      await mutateSaveAlert(Query)({ ...reducedAlert, id: apiAlert?.id ?? null })
+      await mutateSaveAlert(Query)({ ...reducedAlert, id: alert?.id ?? null })
 
       close()
     } catch (e) {
@@ -53,7 +53,7 @@
     <div class="mb-6 flex w-full items-center justify-between border-b pb-4">
       <h2 class="text-xl">{schema.ui.label}</h2>
 
-      {#if !apiAlert}
+      {#if !alert}
         <Button
           variant="plain"
           icon="arrow"

--- a/src/lib/ui/app/Alerts/Dialog/AlertFormScreen.svelte
+++ b/src/lib/ui/app/Alerts/Dialog/AlertFormScreen.svelte
@@ -26,9 +26,9 @@
   async function onAlertCreate() {
     try {
       loading = true
-      const reducedAlert = createApiAlert() as TApiAlert
+      const reducedAlert = createApiAlert()
 
-      await mutateSaveAlert(Query)(reducedAlert)
+      await mutateSaveAlert(Query)({ ...reducedAlert, id: apiAlert?.id ?? null })
 
       close()
     } catch (e) {
@@ -42,7 +42,7 @@
   function createApiAlert() {
     return steps.reduce((acc, step) => step.reduceToApi(acc, $state.snapshot(step.state.$$)), {
       settings: {},
-    })
+    }) as Omit<TApiAlert, 'id'>
   }
 </script>
 

--- a/src/lib/ui/app/Alerts/Dialog/AlertsDialog.svelte
+++ b/src/lib/ui/app/Alerts/Dialog/AlertsDialog.svelte
@@ -18,7 +18,7 @@
   import { type TApiAlert } from '../types.js'
   import { deduceApiAlertSchema, type TAlertSchemaUnion } from '../categories/index.js'
 
-  type TProps = TDialogProps & { source?: string; apiAlert?: null | TApiAlert }
+  type TProps = TDialogProps & { source?: string; apiAlert?: null | Partial<TApiAlert> }
   let { apiAlert, Controller, source = '' }: TProps = $props()
 
   let schema = $state.raw(deduceApiAlertSchema(apiAlert))

--- a/src/lib/ui/app/Alerts/Dialog/AlertsDialog.svelte
+++ b/src/lib/ui/app/Alerts/Dialog/AlertsDialog.svelte
@@ -18,16 +18,16 @@
   import { type TApiAlert } from '../types.js'
   import { deduceApiAlertSchema, type TAlertSchemaUnion } from '../categories/index.js'
 
-  type TProps = TDialogProps & { source?: string; apiAlert?: null | Partial<TApiAlert> }
-  let { apiAlert, Controller, source = '' }: TProps = $props()
+  type TProps = TDialogProps & { source?: string; alert?: null | Partial<TApiAlert> }
+  let { alert, Controller, source = '' }: TProps = $props()
 
-  let schema = $state.raw(deduceApiAlertSchema(apiAlert))
+  let schema = $state.raw(deduceApiAlertSchema(alert))
 
-  const isApiAlertDeduceFailed = $derived(apiAlert && !schema)
+  const isApiAlertDeduceFailed = $derived(alert && !schema)
 
   $effect(() => {
     if (isApiAlertDeduceFailed) {
-      apiAlert = null
+      alert = null
     }
   })
 
@@ -61,7 +61,7 @@
   </h2>
 
   {#if schema}
-    <AlertFormScreen {apiAlert} {schema} {resetCategory} {close}></AlertFormScreen>
+    <AlertFormScreen {alert} {schema} {resetCategory} {close}></AlertFormScreen>
   {:else}
     <CategoriesScreen onSelect={onCategorySelect}></CategoriesScreen>
   {/if}

--- a/src/lib/ui/app/Alerts/Dialog/Steps.svelte
+++ b/src/lib/ui/app/Alerts/Dialog/Steps.svelte
@@ -15,9 +15,13 @@
 
 <nav class="w-full">
   {#each steps as step, i}
-    {@const { title, description } = step.ui}
+    {@const {
+      state,
+      isValid,
+      ui: { title, description, Legend },
+    } = step}
     {@const active = selectedIndex === i}
-    {@const valid = step.isValid.$}
+    {@const valid = isValid.$}
     {@const next = !valid && (steps[i - 1] ? steps[i - 1].isValid.$ : true)}
 
     <button
@@ -46,9 +50,9 @@
 
       <div class="min-w-0 text-start">
         <h3 class="text-base">{title}</h3>
-        {#if valid && step.ui.Legend}
+        {#if valid && Legend}
           <div class="mt-2 flex text-fiord">
-            <step.ui.Legend {step} />
+            <Legend {state} />
           </div>
         {:else if active}
           <p class="text-fiord">

--- a/src/lib/ui/app/Alerts/categories/asset/asset-form-step/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/asset/asset-form-step/schema.ts
@@ -10,7 +10,7 @@ import Legend from './ui/Legend.svelte'
 export type TBaseSchema = TStepBaseSchema<
   'assets',
   {
-    initState: (apiAlert?: null | TAssetApiAlert) => TAssetState
+    initState: (apiAlert?: null | Partial<TAssetApiAlert>) => TAssetState
   }
 >
 

--- a/src/lib/ui/app/Alerts/categories/asset/asset-form-step/ui/Legend.svelte
+++ b/src/lib/ui/app/Alerts/categories/asset/asset-form-step/ui/Legend.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
-  import type { TAlertStep } from '$ui/app/Alerts/form-steps/index.svelte.js'
+  import type { TBaseState } from '$ui/app/Alerts/form-steps/index.svelte.js'
   import type { TBaseSchema } from '../schema.js'
 
   import { useAssetsCtx } from '$lib/ctx/assets/index.svelte.js'
   import StepValue from '$ui/app/Alerts/Dialog/StepValue.svelte'
   import AssetLogo from '$ui/app/AssetLogo/AssetLogo.svelte'
 
-  type TProps = { step: TAlertStep<TBaseSchema> }
+  type TProps = { state: TBaseState<TBaseSchema> }
 
-  let { step }: TProps = $props()
+  const { state }: TProps = $props()
 
   const { getAssetBySlug } = useAssetsCtx()
 
   const MAX = 3
 
-  const slugs = $derived(step.state.$$.target.slugs)
+  const slugs = $derived(state.$$.target.slugs)
   const visible = $derived(slugs.slice(0, MAX))
 </script>
 

--- a/src/lib/ui/app/Alerts/categories/asset/asset-form-step/ui/index.svelte
+++ b/src/lib/ui/app/Alerts/categories/asset/asset-form-step/ui/index.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { TBaseSchema } from '../schema.js'
-  import type { TAlertStep } from '$ui/app/Alerts/form-steps/index.svelte.js'
+  import type { TBaseState } from '$ui/app/Alerts/form-steps/index.svelte.js'
   import type { TAssetSlug } from '$lib/ctx/assets/api.js'
 
   import { SvelteSet } from 'svelte/reactivity'
@@ -10,17 +10,17 @@
 
   import { mapSlugNames } from '../../utils.js'
 
-  type TProps = { step: TAlertStep<TBaseSchema> }
+  type TProps = { state: TBaseState<TBaseSchema> }
 
-  let { step }: TProps = $props()
+  const { state }: TProps = $props()
 
   const { getAssetBySlug } = useAssetsCtx()
 
-  const selectedSlugs = new SvelteSet(step.state.$$.target.slugs)
+  const selectedSlugs = new SvelteSet(state.$$.target.slugs)
 
   $effect(() => {
     const slugs = Array.from(selectedSlugs)
-    step.state.$$.target = { slugs, namesMap: mapSlugNames(slugs, getAssetBySlug) }
+    state.$$.target = { slugs, namesMap: mapSlugNames(slugs, getAssetBySlug) }
   })
 
   function onSelect(slug: TAssetSlug) {

--- a/src/lib/ui/app/Alerts/categories/asset/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/asset/schema.ts
@@ -19,7 +19,7 @@ export type TBaseSchema = TAlertBaseSchema<
   'asset',
   {
     steps: [typeof STEP_ASSETS_SCHEMA, typeof STEP_METRIC_CONDITIONS_SCHEMA]
-    deduceApiAlert: (apiAlert: TAssetApiAlert) => boolean
+    deduceApiAlert: (apiAlert: Partial<TAssetApiAlert>) => boolean
   }
 >
 

--- a/src/lib/ui/app/Alerts/categories/index.ts
+++ b/src/lib/ui/app/Alerts/categories/index.ts
@@ -28,6 +28,8 @@ export const SchemaByType = SCHEMAS.reduce(
 
 export type TAlertSchemaUnion = (typeof SCHEMAS)[number]
 
-export function deduceApiAlertSchema(apiAlert?: null | TApiAlert): null | TAlertSchemaUnion {
+export function deduceApiAlertSchema(
+  apiAlert?: null | Partial<TApiAlert>,
+): null | TAlertSchemaUnion {
   return (apiAlert && SCHEMAS.find((schema) => schema.deduceApiAlert(apiAlert))) || null
 }

--- a/src/lib/ui/app/Alerts/categories/screener/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/screener/schema.ts
@@ -2,13 +2,12 @@ import type { TApiAlert } from '../../types.js'
 
 import { STEP_SELECT_SCREENER_SCHEMA } from './screener-form-step/schema.js'
 import { createAlertSchema, type TAlertBaseSchema } from '../types.js'
-import { type Watchlist } from '../watchlist/api.js'
 import { describeNotifications } from '../../form-steps/notifications-privacy/utils.js'
 
 export type TScreenerApiAlert = TApiAlert<{
   type: 'screener_signal'
   metric: 'social_volume_total'
-  target: { watchlist_id: Watchlist['id'] | null }
+  target: { watchlist_id: number | null }
 }>
 
 export type TBaseSchema = TAlertBaseSchema<

--- a/src/lib/ui/app/Alerts/categories/screener/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/screener/schema.ts
@@ -16,7 +16,7 @@ export type TBaseSchema = TAlertBaseSchema<
   {
     steps: [typeof STEP_SELECT_SCREENER_SCHEMA]
 
-    deduceApiAlert: (apiAlert: TScreenerApiAlert) => boolean
+    deduceApiAlert: (apiAlert: Partial<TScreenerApiAlert>) => boolean
   }
 >
 

--- a/src/lib/ui/app/Alerts/categories/screener/screener-form-step/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/screener/screener-form-step/schema.ts
@@ -17,7 +17,7 @@ export type TScreenerState = {
 export type TBaseSchema = TStepBaseSchema<
   'screener',
   {
-    initState: (apiAlert?: null | TScreenerApiAlert) => TScreenerState
+    initState: (apiAlert?: null | Partial<TScreenerApiAlert>) => TScreenerState
   }
 >
 

--- a/src/lib/ui/app/Alerts/categories/screener/screener-form-step/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/screener/screener-form-step/schema.ts
@@ -1,5 +1,4 @@
 import type { TScreenerApiAlert } from '../schema.js'
-import type { Watchlist } from '../../watchlist/api.js'
 
 import { createStepSchema, type TStepBaseSchema } from '$ui/app/Alerts/form-steps/types.js'
 
@@ -9,7 +8,7 @@ import Legend from './ui/Legend.svelte'
 export type TScreenerState = {
   metric: NonNullable<TScreenerApiAlert['settings']>['metric']
   screener: {
-    id: Watchlist['id'] | null
+    id: number | null
     title: string
   }
 }

--- a/src/lib/ui/app/Alerts/categories/screener/screener-form-step/ui/Legend.svelte
+++ b/src/lib/ui/app/Alerts/categories/screener/screener-form-step/ui/Legend.svelte
@@ -1,22 +1,22 @@
 <script lang="ts">
-  import type { TAlertStep } from '$ui/app/Alerts/form-steps/index.svelte.js'
+  import type { TBaseState } from '$ui/app/Alerts/form-steps/index.svelte.js'
   import type { TBaseSchema } from '../schema.js'
 
   import StepValue from '$ui/app/Alerts/Dialog/StepValue.svelte'
 
   import { useUserWatchlistsCtx } from '../../../watchlist/data.svelte.js'
 
-  type TProps = { step: TAlertStep<TBaseSchema> }
+  type TProps = { state: TBaseState<TBaseSchema> }
 
-  let { step }: TProps = $props()
+  const { state }: TProps = $props()
 
   const { getWatchlistById } = useUserWatchlistsCtx({ loadScreeners: true })
 
-  const { id, title } = $derived(step.state.$$.screener)
+  const { id, title } = $derived(state.$$.screener)
 
   $effect(() => {
     if (id && !title) {
-      step.state.$$.screener.title = getWatchlistById(id.toString())?.title ?? ''
+      state.$$.screener.title = getWatchlistById(id.toString())?.title ?? ''
     }
   })
 </script>

--- a/src/lib/ui/app/Alerts/categories/screener/screener-form-step/ui/Legend.svelte
+++ b/src/lib/ui/app/Alerts/categories/screener/screener-form-step/ui/Legend.svelte
@@ -16,7 +16,7 @@
 
   $effect(() => {
     if (id && !title) {
-      step.state.$$.screener.title = getWatchlistById(id)?.title ?? ''
+      step.state.$$.screener.title = getWatchlistById(id.toString())?.title ?? ''
     }
   })
 </script>

--- a/src/lib/ui/app/Alerts/categories/screener/screener-form-step/ui/index.svelte
+++ b/src/lib/ui/app/Alerts/categories/screener/screener-form-step/ui/index.svelte
@@ -14,6 +14,9 @@
 <ListOfWatchlists
   {selectedId}
   onSelect={(screener) =>
-    (step.state.$$.screener = { id: screener?.id ?? null, title: screener?.title ?? '' })}
+    (step.state.$$.screener = {
+      id: screener?.id ? +screener.id : null,
+      title: screener?.title ?? '',
+    })}
   loadScreeners
 />

--- a/src/lib/ui/app/Alerts/categories/screener/screener-form-step/ui/index.svelte
+++ b/src/lib/ui/app/Alerts/categories/screener/screener-form-step/ui/index.svelte
@@ -6,15 +6,17 @@
 
   type TProps = { step: TAlertStep<TBaseSchema> }
 
-  let { step }: TProps = $props()
+  const { step }: TProps = $props()
 
-  const selectedId = $derived(step.state.$$.screener.id)
+  const state = step.state
+
+  const selectedId = $derived(state.$$.screener.id)
 </script>
 
 <ListOfWatchlists
   {selectedId}
   onSelect={(screener) =>
-    (step.state.$$.screener = {
+    (state.$$.screener = {
       id: screener?.id ? +screener.id : null,
       title: screener?.title ?? '',
     })}

--- a/src/lib/ui/app/Alerts/categories/screener/screener-form-step/ui/index.svelte
+++ b/src/lib/ui/app/Alerts/categories/screener/screener-form-step/ui/index.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
   import type { TBaseSchema } from '../schema.js'
-  import type { TAlertStep } from '$ui/app/Alerts/form-steps/index.svelte.js'
+  import type { TBaseState } from '$ui/app/Alerts/form-steps/index.svelte.js'
 
   import ListOfWatchlists from '../../../watchlist/watchlist-form-step/ui/ListOfWatchlists.svelte'
 
-  type TProps = { step: TAlertStep<TBaseSchema> }
+  type TProps = { state: TBaseState<TBaseSchema> }
 
-  const { step }: TProps = $props()
-
-  const state = step.state
+  const { state }: TProps = $props()
 
   const selectedId = $derived(state.$$.screener.id)
 </script>

--- a/src/lib/ui/app/Alerts/categories/social-trends/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/social-trends/schema.ts
@@ -32,7 +32,7 @@ export type TBaseSchema = TAlertBaseSchema<
   {
     steps: [typeof STEP_SELECT_TREND_SCHEMA]
 
-    deduceApiAlert: (apiAlert: TSocialTrendsApiAlert) => boolean
+    deduceApiAlert: (apiAlert: Partial<TSocialTrendsApiAlert>) => boolean
   }
 >
 

--- a/src/lib/ui/app/Alerts/categories/social-trends/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/social-trends/schema.ts
@@ -2,7 +2,6 @@ import type { TApiAlert } from '../../types.js'
 import type { TAssetSlug } from '$lib/ctx/assets/index.js'
 
 import { createAlertSchema, type TAlertBaseSchema } from '../types.js'
-import { type Watchlist } from '../watchlist/api.js'
 import { STEP_SELECT_TREND_SCHEMA } from './select-trend-form-step/schema.js'
 import { getAssetTargetTitle } from '../asset/utils.js'
 
@@ -19,7 +18,7 @@ export type TSocialTrendsApiAlert = TApiAlert<
         operation: { trending_word: true }
       }
     | {
-        target: { watchlist_id: Watchlist['id'] | null }
+        target: { watchlist_id: number | null }
         operation: { trending_project: true }
       }
   )

--- a/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/schema.ts
@@ -1,6 +1,5 @@
 import type { TSocialTrendsApiAlert } from '../schema.js'
 import type { TAssetSlug } from '$lib/ctx/assets/api.js'
-import type { Watchlist } from '../../watchlist/api.js'
 
 import { createStepSchema, type TStepBaseSchema } from '$ui/app/Alerts/form-steps/types.js'
 
@@ -19,7 +18,7 @@ type TWordTarget = {
 }
 
 type TWatchlistTarget = {
-  id: Watchlist['id'] | null
+  id: number | null
   title: string
   type: 'watchlist'
 }

--- a/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/schema.ts
@@ -32,7 +32,7 @@ export type TTrendState = {
 export type TBaseSchema = TStepBaseSchema<
   'select-trend',
   {
-    initState: (apiAlert?: null | TSocialTrendsApiAlert) => TTrendState
+    initState: (apiAlert?: null | Partial<TSocialTrendsApiAlert>) => TTrendState
   }
 >
 

--- a/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/ui/Watchlist.svelte
+++ b/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/ui/Watchlist.svelte
@@ -16,7 +16,7 @@
   function onSelect(watchlist: Watchlist | null) {
     stepState.$$.target = {
       type: 'watchlist',
-      id: watchlist?.id ?? null,
+      id: watchlist?.id ? +watchlist.id : null,
       title: watchlist?.title ?? '',
     }
   }

--- a/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/ui/index.svelte
+++ b/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/ui/index.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { TBaseSchema, TTrendState } from '../schema.js'
-  import type { TAlertStep } from '$ui/app/Alerts/form-steps/index.svelte.js'
+  import type { TBaseState } from '$ui/app/Alerts/form-steps/index.svelte.js'
   import type { Component } from 'svelte'
 
   import Button from '$ui/core/Button/index.js'
@@ -26,17 +26,16 @@
   const TABS = exactObjectKeys(TAB_MAP)
   type TabKey = TTrendState['target']['type']
 
-  type TProps = { step: TAlertStep<TBaseSchema> }
+  type TProps = { state: TBaseState<TBaseSchema> }
 
-  let { step }: TProps = $props()
+  const { state }: TProps = $props()
 
-  const { target } = $derived(step.state.$$)
-
+  const { target } = $derived(state.$$)
   const selectedTab = $derived(target.type)
   const TabComponent = $derived(TAB_MAP[selectedTab].Component)
 
   function selectTab(tab: TabKey) {
-    step.state.$$.target = getInitTrendTarget(tab)
+    state.$$.target = getInitTrendTarget(tab)
   }
 </script>
 
@@ -64,6 +63,6 @@
   </nav>
 
   {#if TabComponent}
-    <TabComponent stepState={step.state} />
+    <TabComponent stepState={state} />
   {/if}
 </section>

--- a/src/lib/ui/app/Alerts/categories/types.ts
+++ b/src/lib/ui/app/Alerts/categories/types.ts
@@ -24,7 +24,7 @@ export type TAlertBaseSchema<
   GName,
   GProps extends {
     steps: TStepSchema[]
-    deduceApiAlert: (apiAlert: TApiAlert) => boolean
+    deduceApiAlert: (apiAlert: Partial<TApiAlert>) => boolean
   },
 > = {
   name: GName

--- a/src/lib/ui/app/Alerts/categories/wallet/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/wallet/schema.ts
@@ -27,7 +27,7 @@ export type TBaseSchema = TAlertBaseSchema<
   {
     steps: [typeof STEP_SELECT_WALLET_SCHEMA]
 
-    deduceApiAlert: (apiAlert: TWalletApiAlert) => boolean
+    deduceApiAlert: (apiAlert: Partial<TWalletApiAlert>) => boolean
   }
 >
 

--- a/src/lib/ui/app/Alerts/categories/wallet/wallet-form-step/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/wallet/wallet-form-step/schema.ts
@@ -25,7 +25,7 @@ export type TWalletState = {
 export type TBaseSchema = TStepBaseSchema<
   'wallet',
   {
-    initState: (apiAlert?: null | TWalletApiAlert) => TWalletState
+    initState: (apiAlert?: null | Partial<TWalletApiAlert>) => TWalletState
   }
 >
 

--- a/src/lib/ui/app/Alerts/categories/wallet/wallet-form-step/ui/index.svelte
+++ b/src/lib/ui/app/Alerts/categories/wallet/wallet-form-step/ui/index.svelte
@@ -23,7 +23,7 @@
 
 <script lang="ts">
   import type { TBaseSchema } from '../schema.js'
-  import type { TAlertStep } from '$ui/app/Alerts/form-steps/index.svelte.js'
+  import type { TBaseState } from '$ui/app/Alerts/form-steps/index.svelte.js'
 
   import Button from '$ui/core/Button/index.js'
   import Input from '$ui/core/Input/index.js'
@@ -33,14 +33,14 @@
   import Capitalisation from './Capitalisation.svelte'
   import AssetMovements from './AssetMovements.svelte'
 
-  type TProps = { step: TAlertStep<TBaseSchema> }
+  type TProps = { state: TBaseState<TBaseSchema> }
 
-  let { step }: TProps = $props()
+  const { state }: TProps = $props()
 
   const {
     target: { address, infrastructure },
     type: alertType,
-  } = $derived(step.state.$$)
+  } = $derived(state.$$)
 </script>
 
 <section>
@@ -59,7 +59,7 @@
       class="group-hover:border-green"
       defaultValue={address ?? ''}
       oninput={({ currentTarget }) => {
-        step.state.$$.target.address = currentTarget.value
+        state.$$.target.address = currentTarget.value
       }}
     />
   </label>
@@ -79,7 +79,7 @@
         )}
         {disabled}
         onclick={() => {
-          step.state.$$.type = type
+          state.$$.type = type
         }}
       >
         <div class="flex justify-between">
@@ -99,8 +99,8 @@
   </section>
 
   {#if alertType === 'wallet_movement'}
-    <AssetMovements stepState={step.state} />
+    <AssetMovements stepState={state} />
   {:else if alertType === 'wallet_usd_valuation'}
-    <Capitalisation stepState={step.state} />
+    <Capitalisation stepState={state} />
   {/if}
 </section>

--- a/src/lib/ui/app/Alerts/categories/watchlist/api.ts
+++ b/src/lib/ui/app/Alerts/categories/watchlist/api.ts
@@ -1,7 +1,7 @@
 import { ApiQuery } from '$lib/api/index.js'
 
 export type Watchlist = {
-  id: string | number
+  id: string
   title: string
   description: string | null
   isScreener: boolean

--- a/src/lib/ui/app/Alerts/categories/watchlist/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/watchlist/schema.ts
@@ -17,7 +17,7 @@ export type TBaseSchema = TAlertBaseSchema<
   'watchlist',
   {
     steps: [typeof STEP_SELECT_WATCHLIST_SCHEMA, typeof STEP_METRIC_CONDITIONS_SCHEMA]
-    deduceApiAlert: (apiAlert: TWatchlistApiAlert) => boolean
+    deduceApiAlert: (apiAlert: Partial<TWatchlistApiAlert>) => boolean
   }
 >
 

--- a/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/schema.ts
@@ -9,7 +9,7 @@ import Legend from './ui/Legend.svelte'
 export type TBaseSchema = TStepBaseSchema<
   'watchlist',
   {
-    initState: (apiAlert?: null | TWatchlistApiAlert) => TWatchlistState
+    initState: (apiAlert?: null | Partial<TWatchlistApiAlert>) => TWatchlistState
   }
 >
 

--- a/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/state.ts
+++ b/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/state.ts
@@ -1,8 +1,6 @@
-import type { Watchlist } from '../api.js'
-
 export type TWatchlistState = {
   watchlist: {
-    id: Watchlist['id'] | null
+    id: number | null
     title: string
   }
 }

--- a/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/ui/Legend.svelte
+++ b/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/ui/Legend.svelte
@@ -16,7 +16,7 @@
 
   $effect(() => {
     if (id && !title) {
-      step.state.$$.watchlist.title = getWatchlistById(id)?.title ?? ''
+      step.state.$$.watchlist.title = getWatchlistById(id.toString())?.title ?? ''
     }
   })
 </script>

--- a/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/ui/Legend.svelte
+++ b/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/ui/Legend.svelte
@@ -1,22 +1,22 @@
 <script lang="ts">
-  import type { TAlertStep } from '$ui/app/Alerts/form-steps/index.svelte.js'
+  import type { TBaseState } from '$ui/app/Alerts/form-steps/index.svelte.js'
   import type { TBaseSchema } from '../schema.js'
 
   import StepValue from '$ui/app/Alerts/Dialog/StepValue.svelte'
 
   import { useUserWatchlistsCtx } from '../../data.svelte.js'
 
-  type TProps = { step: TAlertStep<TBaseSchema> }
+  type TProps = { state: TBaseState<TBaseSchema> }
 
-  let { step }: TProps = $props()
+  const { state }: TProps = $props()
 
   const { getWatchlistById } = useUserWatchlistsCtx()
 
-  const { id, title } = $derived(step.state.$$.watchlist)
+  const { id, title } = $derived(state.$$.watchlist)
 
   $effect(() => {
     if (id && !title) {
-      step.state.$$.watchlist.title = getWatchlistById(id.toString())?.title ?? ''
+      state.$$.watchlist.title = getWatchlistById(id.toString())?.title ?? ''
     }
   })
 </script>

--- a/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/ui/ListOfWatchlists.svelte
+++ b/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/ui/ListOfWatchlists.svelte
@@ -11,7 +11,7 @@
   import { useUserWatchlistsCtx } from '../../data.svelte.js'
 
   type TProps = {
-    selectedId: Watchlist['id'] | null
+    selectedId: number | null
     onSelect: (watchlist: Watchlist | null) => void
     loadScreeners?: boolean
   }
@@ -37,7 +37,7 @@
   <section class="flex flex-col gap-3">
     {#each filteredWatchlists as watchlist}
       {@const { id, title, description } = watchlist}
-      {@const isActive = selectedId === id}
+      {@const isActive = selectedId === +id}
 
       <Button
         variant="plain"

--- a/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/ui/index.svelte
+++ b/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/ui/index.svelte
@@ -14,5 +14,8 @@
 <ListOfWatchlists
   {selectedId}
   onSelect={(watchlist) =>
-    (step.state.$$.watchlist = { id: watchlist?.id ?? null, title: watchlist?.title ?? '' })}
+    (step.state.$$.watchlist = {
+      id: watchlist?.id ? +watchlist.id : null,
+      title: watchlist?.title ?? '',
+    })}
 />

--- a/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/ui/index.svelte
+++ b/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/ui/index.svelte
@@ -1,14 +1,12 @@
 <script lang="ts">
   import type { TBaseSchema } from '../schema.js'
-  import type { TAlertStep } from '$ui/app/Alerts/form-steps/index.svelte.js'
+  import type { TBaseState } from '$ui/app/Alerts/form-steps/index.svelte.js'
 
   import ListOfWatchlists from './ListOfWatchlists.svelte'
 
-  type TProps = { step: TAlertStep<TBaseSchema> }
+  type TProps = { state: TBaseState<TBaseSchema> }
 
-  const { step }: TProps = $props()
-
-  const state = step.state
+  const { state }: TProps = $props()
 
   const selectedId = $derived(state.$$.watchlist.id)
 </script>

--- a/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/ui/index.svelte
+++ b/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/ui/index.svelte
@@ -6,15 +6,17 @@
 
   type TProps = { step: TAlertStep<TBaseSchema> }
 
-  let { step }: TProps = $props()
+  const { step }: TProps = $props()
 
-  const selectedId = $derived(step.state.$$.watchlist.id)
+  const state = step.state
+
+  const selectedId = $derived(state.$$.watchlist.id)
 </script>
 
 <ListOfWatchlists
   {selectedId}
   onSelect={(watchlist) =>
-    (step.state.$$.watchlist = {
+    (state.$$.watchlist = {
       id: watchlist?.id ? +watchlist.id : null,
       title: watchlist?.title ?? '',
     })}

--- a/src/lib/ui/app/Alerts/ctx/index.svelte.ts
+++ b/src/lib/ui/app/Alerts/ctx/index.svelte.ts
@@ -7,7 +7,7 @@ import { createAlertStep } from '../form-steps/index.svelte.js'
 
 export const useAlertFormCtx = createCtx(
   'alerts_useAlertFormCtx',
-  ({ schema, apiAlert }: { schema: TAlertSchemaUnion; apiAlert?: null | TApiAlert }) => {
+  ({ schema, apiAlert }: { schema: TAlertSchemaUnion; apiAlert?: null | Partial<TApiAlert> }) => {
     const steps = schema.steps.map((step) => createAlertStep(apiAlert, step))
 
     let selectedIndex = $state(0)

--- a/src/lib/ui/app/Alerts/ctx/index.svelte.ts
+++ b/src/lib/ui/app/Alerts/ctx/index.svelte.ts
@@ -7,8 +7,8 @@ import { createAlertStep } from '../form-steps/index.svelte.js'
 
 export const useAlertFormCtx = createCtx(
   'alerts_useAlertFormCtx',
-  ({ schema, apiAlert }: { schema: TAlertSchemaUnion; apiAlert?: null | Partial<TApiAlert> }) => {
-    const steps = schema.steps.map((step) => createAlertStep(apiAlert, step))
+  ({ schema, alert }: { schema: TAlertSchemaUnion; alert?: null | Partial<TApiAlert> }) => {
+    const steps = schema.steps.map((step) => createAlertStep(alert, step))
 
     let selectedIndex = $state(0)
     const selectedStep = $derived(steps[selectedIndex])

--- a/src/lib/ui/app/Alerts/form-steps/index.svelte.ts
+++ b/src/lib/ui/app/Alerts/form-steps/index.svelte.ts
@@ -3,7 +3,7 @@ import type { TStepBaseSchema, TStepSchema, TStepUI } from './types.js'
 import type { IfAny } from '$lib/utils/types/index.js'
 
 export function createAlertStep<GStepSchema extends TStepSchema>(
-  apiAlert: undefined | null | TApiAlert,
+  apiAlert: undefined | null | Partial<TApiAlert>,
   schema: GStepSchema,
 ) {
   let _state = $state<{ [key: string]: unknown }>(schema.initState(apiAlert))

--- a/src/lib/ui/app/Alerts/form-steps/index.svelte.ts
+++ b/src/lib/ui/app/Alerts/form-steps/index.svelte.ts
@@ -5,8 +5,8 @@ import type { IfAny } from '$lib/utils/types/index.js'
 export function createAlertStep<GStepSchema extends TStepSchema>(
   apiAlert: undefined | null | Partial<TApiAlert>,
   schema: GStepSchema,
-) {
-  let _state = $state<{ [key: string]: unknown }>(schema.initState(apiAlert))
+): TAlertStep<GStepSchema> {
+  let _state = $state<ReturnType<GStepSchema['initState']>>(schema.initState(apiAlert))
   const _isValid = $derived(schema.validate(_state))
 
   return {
@@ -33,29 +33,33 @@ export function createAlertStep<GStepSchema extends TStepSchema>(
   }
 }
 
+export type TBaseState<
+  GStepSchema extends TStepBaseSchema<string, any> = TStepBaseSchema<string, any>,
+> = {
+  get $$(): IfAny<
+    ReturnType<GStepSchema['initState']>,
+    unknown,
+    ReturnType<GStepSchema['initState']>
+  >
+
+  set $$(
+    value: IfAny<
+      ReturnType<GStepSchema['initState']>,
+      unknown,
+      ReturnType<GStepSchema['initState']>
+    >,
+  )
+}
+
 export type TAlertStep<
   GStepSchema extends TStepBaseSchema<string, any> = TStepBaseSchema<string, any>,
 > = {
   name: GStepSchema['name']
-  ui: TStepUI['ui']
+  ui: TStepUI<{ state: TBaseState<GStepSchema> }>['ui']
 
   reduceToApi: GStepSchema['reduceToApi']
 
-  state: {
-    get $$(): IfAny<
-      ReturnType<GStepSchema['initState']>,
-      unknown,
-      ReturnType<GStepSchema['initState']>
-    >
-
-    set $$(
-      value: IfAny<
-        ReturnType<GStepSchema['initState']>,
-        unknown,
-        ReturnType<GStepSchema['initState']>
-      >,
-    )
-  }
+  state: TBaseState<GStepSchema>
 
   isValid: {
     get $(): boolean

--- a/src/lib/ui/app/Alerts/form-steps/metric-conditions/schema.ts
+++ b/src/lib/ui/app/Alerts/form-steps/metric-conditions/schema.ts
@@ -32,7 +32,7 @@ export type TMetricConditionsState = {
 export type TBaseSchema = TStepBaseSchema<
   'metric-conditions',
   {
-    initState: (alert?: TApiAlert<TAlertSettings> | null) => TMetricConditionsState
+    initState: (alert?: Partial<TApiAlert<TAlertSettings>> | null) => TMetricConditionsState
   }
 >
 

--- a/src/lib/ui/app/Alerts/form-steps/metric-conditions/schema.ts
+++ b/src/lib/ui/app/Alerts/form-steps/metric-conditions/schema.ts
@@ -47,7 +47,7 @@ export const STEP_METRIC_CONDITIONS_SCHEMA = createStepSchema<TBaseSchema>({
         type: 'above',
         values: [1, 1],
       },
-      time: alert?.settings ? getTimeFromApi(alert.settings.time_window) : '1d',
+      time: alert?.settings?.time_window ? getTimeFromApi(alert.settings.time_window) : '1d',
     },
   }),
 

--- a/src/lib/ui/app/Alerts/form-steps/metric-conditions/ui/Legend.svelte
+++ b/src/lib/ui/app/Alerts/form-steps/metric-conditions/ui/Legend.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { TAlertStep } from '../../index.svelte.js'
+  import type { TBaseState } from '../../index.svelte.js'
   import type { TBaseSchema } from '../schema.js'
 
   import StepValue from '$ui/app/Alerts/Dialog/StepValue.svelte'
@@ -7,17 +7,17 @@
 
   import { describeConditions } from '../utils.js'
 
-  type TProps = { step: TAlertStep<TBaseSchema> }
+  type TProps = { state: TBaseState<TBaseSchema> }
 
-  let { step }: TProps = $props()
+  let { state }: TProps = $props()
 
   const { MetricsRegistry } = useMetricsRegistryCtx()
 
-  const { metric, metricLabel, conditions } = $derived(step.state.$$)
+  const { metric, metricLabel, conditions } = $derived(state.$$)
 
   $effect(() => {
     if (metric && !metricLabel) {
-      step.state.$$.metricLabel = MetricsRegistry.$[metric]?.label ?? ''
+      state.$$.metricLabel = MetricsRegistry.$[metric]?.label ?? ''
     }
   })
 </script>

--- a/src/lib/ui/app/Alerts/form-steps/metric-conditions/ui/index.svelte
+++ b/src/lib/ui/app/Alerts/form-steps/metric-conditions/ui/index.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { TBaseSchema } from '../schema.js'
-  import type { TAlertStep } from '../../index.svelte.js'
+  import type { TBaseState } from '../../index.svelte.js'
 
   import { useMetricsRegistryCtx } from '$lib/ctx/metrics-registry/index.svelte.js'
 
@@ -8,24 +8,25 @@
   import Conditions from './Conditions.svelte'
   import Metric from './Metric.svelte'
 
-  type TProps = { step: TAlertStep<TBaseSchema> }
+  type TProps = { state: TBaseState<TBaseSchema> }
 
-  let { step }: TProps = $props()
+  const { state }: TProps = $props()
+
   const { MetricsRegistry } = useMetricsRegistryCtx()
 
-  const { metric: selectedMetricKey, metricLabel, conditions } = $derived(step.state.$$)
+  const { metric: selectedMetricKey, metricLabel, conditions } = $derived(state.$$)
   const metric = $derived(selectedMetricKey ? (MetricsRegistry.$[selectedMetricKey] ?? null) : null)
   let isMetricScreen = $derived(!metric)
 
   $effect(() => {
     // Used to fill metric label in case state filled from ApiAlert
     if (selectedMetricKey && !metricLabel) {
-      step.state.$$.metricLabel = metric?.label ?? ''
+      state.$$.metricLabel = metric?.label ?? ''
     }
   })
 
   function onMetricSelect(metric: string) {
-    step.state.$$.metric = metric
+    state.$$.metric = metric
     isMetricScreen = false
   }
 
@@ -40,7 +41,7 @@
   <Conditions
     {conditions}
     metric={selectedMetricKey}
-    updateConditions={(conditions) => (step.state.$$.conditions = conditions)}
+    updateConditions={(conditions) => (state.$$.conditions = conditions)}
   >
     <Metric label={metricLabel} onclick={onScreenToggle} />
   </Conditions>

--- a/src/lib/ui/app/Alerts/form-steps/name-description/schema.ts
+++ b/src/lib/ui/app/Alerts/form-steps/name-description/schema.ts
@@ -4,7 +4,7 @@ import { createStepSchema, type TStepBaseSchema } from '../types.js'
 import Form from './ui/index.svelte'
 import Legend from './ui/Legend.svelte'
 
-export type TState = {
+export type TNameDescriptionState = {
   title: string
   description: string
 }
@@ -13,7 +13,7 @@ export type TState = {
 export type TBaseSchema = TStepBaseSchema<
   'name-description',
   {
-    initState: (apiAlert?: null | Partial<TApiAlert>) => TState
+    initState: (apiAlert?: null | Partial<TApiAlert>) => TNameDescriptionState
   }
 >
 

--- a/src/lib/ui/app/Alerts/form-steps/name-description/schema.ts
+++ b/src/lib/ui/app/Alerts/form-steps/name-description/schema.ts
@@ -13,7 +13,7 @@ export type TState = {
 export type TBaseSchema = TStepBaseSchema<
   'name-description',
   {
-    initState: (apiAlert?: null | TApiAlert) => TState
+    initState: (apiAlert?: null | Partial<TApiAlert>) => TState
   }
 >
 

--- a/src/lib/ui/app/Alerts/form-steps/name-description/ui/Legend.svelte
+++ b/src/lib/ui/app/Alerts/form-steps/name-description/ui/Legend.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-  import type { TAlertStep } from '../../index.svelte.js'
+  import type { TBaseState } from '../../index.svelte.js'
   import type { TBaseSchema } from '../schema.js'
 
   type TProps = {
-    step: TAlertStep<TBaseSchema>
+    state: TBaseState<TBaseSchema>
   }
 
-  let { step }: TProps = $props()
+  let { state }: TProps = $props()
 
-  const { title } = $derived(step.state.$$)
+  const { title } = $derived(state.$$)
 </script>
 
 <span class="single-line">{title}</span>

--- a/src/lib/ui/app/Alerts/form-steps/name-description/ui/index.svelte
+++ b/src/lib/ui/app/Alerts/form-steps/name-description/ui/index.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import type { TBaseSchema, TState } from '../schema.js'
-  import type { TAlertStep } from '../../index.svelte.js'
+  import type { TBaseState } from '../../index.svelte.js'
 
   import { onMount } from 'svelte'
 
@@ -8,20 +8,20 @@
   import { useAlertFormCtx } from '$ui/app/Alerts/ctx/index.svelte.js'
 
   type TProps = {
-    step: TAlertStep<TBaseSchema>
+    state: TBaseState<TBaseSchema>
   }
 
-  let { step }: TProps = $props()
+  const { state }: TProps = $props()
 
   const { schema, steps } = useAlertFormCtx.get()
 
   async function suggestTitleAndDesc() {
-    if (!step.state.$$.title) {
-      step.state.$$.title = await schema.suggestTitle(steps)
+    if (!state.$$.title) {
+      state.$$.title = await schema.suggestTitle(steps)
     }
 
-    if (!step.state.$$.description) {
-      step.state.$$.description = await schema.suggestDescription(steps)
+    if (!state.$$.description) {
+      state.$$.description = await schema.suggestDescription(steps)
     }
   }
 
@@ -42,8 +42,8 @@
       class="border-none px-0"
       inputClass="pb-0 resize-none"
       {rows}
-      value={step.state.$$[name]}
-      oninput={(e) => (step.state.$$[name] = e.currentTarget.value)}
+      value={state.$$[name]}
+      oninput={(e) => (state.$$[name] = e.currentTarget.value)}
     />
   </label>
 {/snippet}

--- a/src/lib/ui/app/Alerts/form-steps/name-description/ui/index.svelte
+++ b/src/lib/ui/app/Alerts/form-steps/name-description/ui/index.svelte
@@ -39,8 +39,8 @@
   <label class="title flex flex-col rounded border px-4 py-3">
     <p class="text-xs text-waterloo">{title}</p>
     <Textarea
-      class="border-none px-0"
-      inputClass="pb-0 resize-none"
+      class="border-none"
+      inputClass="pb-0 px-0 resize-none"
       {rows}
       value={state.$$[name]}
       oninput={(e) => (state.$$[name] = e.currentTarget.value)}

--- a/src/lib/ui/app/Alerts/form-steps/name-description/ui/index.svelte
+++ b/src/lib/ui/app/Alerts/form-steps/name-description/ui/index.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { TBaseSchema, TState } from '../schema.js'
+  import type { TBaseSchema, TNameDescriptionState } from '../schema.js'
   import type { TBaseState } from '../../index.svelte.js'
 
   import { onMount } from 'svelte'
@@ -35,7 +35,7 @@
   {@render textarea('Description', 'description', 4)}
 </section>
 
-{#snippet textarea(title: string, name: keyof TState, rows: number)}
+{#snippet textarea(title: string, name: keyof TNameDescriptionState, rows: number)}
   <label class="title flex flex-col rounded border px-4 py-3">
     <p class="text-xs text-waterloo">{title}</p>
     <Textarea

--- a/src/lib/ui/app/Alerts/form-steps/notifications-privacy/schema.ts
+++ b/src/lib/ui/app/Alerts/form-steps/notifications-privacy/schema.ts
@@ -16,7 +16,7 @@ export type TNotificationsState = {
 export type TBaseSchema = TStepBaseSchema<
   'notifications-privacy',
   {
-    initState: (apiAlert?: null | TApiAlert<unknown>) => TNotificationsState
+    initState: (apiAlert?: null | Partial<TApiAlert<unknown>>) => TNotificationsState
   }
 >
 
@@ -37,7 +37,7 @@ export const STEP_NOTIFICATIONS_PRIVACY_SCHEMA = createStepSchema<TBaseSchema>({
       channel: getChannelFromApi(apiAlert?.settings?.channel) ?? {},
       isPublic: apiAlert?.isPublic ?? false,
       isRepeating: apiAlert?.isRepeating ?? true,
-      cooldown: apiAlert ? getTimeFromApi(apiAlert.cooldown) : '1d',
+      cooldown: apiAlert?.cooldown ? getTimeFromApi(apiAlert.cooldown) : '1d',
     }
   },
 

--- a/src/lib/ui/app/Alerts/form-steps/notifications-privacy/ui/Legend.svelte
+++ b/src/lib/ui/app/Alerts/form-steps/notifications-privacy/ui/Legend.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import type { TAlertStep } from '../../index.svelte.js'
+  import type { TBaseState } from '../../index.svelte.js'
   import type { TBaseSchema } from '../schema.js'
 
   import StepValue from '$ui/app/Alerts/Dialog/StepValue.svelte'
@@ -7,11 +7,11 @@
 
   import { formatChannels } from '../utils.js'
 
-  type TProps = { step: TAlertStep<TBaseSchema> }
+  type TProps = { state: TBaseState<TBaseSchema> }
 
-  let { step }: TProps = $props()
+  const { state }: TProps = $props()
 
-  const { channel, isPublic } = $derived(step.state.$$)
+  const { channel, isPublic } = $derived(state.$$)
 
   const formattedChannels = $derived(formatChannels(channel))
 </script>

--- a/src/lib/ui/app/Alerts/form-steps/notifications-privacy/ui/index.svelte
+++ b/src/lib/ui/app/Alerts/form-steps/notifications-privacy/ui/index.svelte
@@ -1,16 +1,14 @@
 <script lang="ts">
   import type { TBaseSchema } from '../schema.js'
-  import type { TAlertStep } from '../../index.svelte.js'
+  import type { TBaseState } from '../../index.svelte.js'
 
   import Notifications from './Notifications.svelte'
   import Frequencies from './Frequencies.svelte'
   import Privacy from './Privacy.svelte'
 
-  type TProps = { step: TAlertStep<TBaseSchema> }
+  type TProps = { state: TBaseState<TBaseSchema> }
 
-  let { step }: TProps = $props()
-
-  const state = $derived(step.state)
+  const { state }: TProps = $props()
 </script>
 
 <section class="flex flex-col gap-4">

--- a/src/lib/ui/app/Alerts/form-steps/types.ts
+++ b/src/lib/ui/app/Alerts/form-steps/types.ts
@@ -4,7 +4,7 @@ import type { TApiAlert } from '../types.js'
 export type TStepBaseSchema<
   GName,
   GProps extends {
-    initState: (apiAlert?: null | TApiAlert) => { [key: string]: unknown }
+    initState: (apiAlert?: null | Partial<TApiAlert>) => { [key: string]: unknown }
   },
 > = {
   name: GName
@@ -33,7 +33,7 @@ export type TStepUI = {
 export type TStepSchema = TStepBaseSchema<
   string,
   {
-    initState: (apiAlert?: null | TApiAlert) => any
+    initState: (apiAlert?: null | Partial<TApiAlert>) => any
   }
 > &
   TStepUI

--- a/src/lib/ui/app/Alerts/form-steps/types.ts
+++ b/src/lib/ui/app/Alerts/form-steps/types.ts
@@ -1,5 +1,6 @@
 import type { Component } from 'svelte'
 import type { TApiAlert } from '../types.js'
+import type { TBaseState } from './index.svelte.js'
 
 export type TStepBaseSchema<
   GName,
@@ -19,14 +20,14 @@ export type TStepBaseSchema<
   ) => { settings: object }
 }
 
-export type TStepUI = {
+export type TStepUI<GState extends Record<string, any>> = {
   ui: {
     title: string
     label: string
     description: string
 
-    Form: Component<any>
-    Legend?: Component<any>
+    Form: Component<GState>
+    Legend?: Component<GState>
   }
 }
 
@@ -36,10 +37,10 @@ export type TStepSchema = TStepBaseSchema<
     initState: (apiAlert?: null | Partial<TApiAlert>) => any
   }
 > &
-  TStepUI
+  TStepUI<any>
 
 export function createStepSchema<GBaseSchema extends TStepBaseSchema<string, any> = any>(
-  base: GBaseSchema & TStepUI,
+  base: GBaseSchema & TStepUI<{ state: TBaseState<GBaseSchema> }>,
 ) {
   const schema = {
     name: base.name as GBaseSchema['name'],

--- a/src/lib/ui/app/Alerts/index.ts
+++ b/src/lib/ui/app/Alerts/index.ts
@@ -1,0 +1,2 @@
+export { showAlertsDialog$ } from './Dialog/index.js'
+export type { TApiAlert } from './types.js'

--- a/src/stories/Design System - App UI/AlertsDialog/index.stories.ts
+++ b/src/stories/Design System - App UI/AlertsDialog/index.stories.ts
@@ -200,7 +200,6 @@ export const PartialScreenerAlert: Story = {
     alert: {
       settings: {
         type: 'screener_signal',
-        metric: null,
         target: { watchlist_id: MOCK_SCREENER_ID },
         operation: { selector: { watchlist_id: MOCK_SCREENER_ID } },
       },
@@ -214,8 +213,32 @@ export const PartialWatchlistAlert: Story = {
     alert: {
       settings: {
         type: 'metric_signal',
-        metric: null,
         target: { watchlist_id: MOCK_WATCHLIST_ID },
+      },
+    },
+  },
+}
+
+export const PartialAssetAlert: Story = {
+  parameters: {},
+  args: {
+    alert: {
+      settings: {
+        type: 'metric_signal',
+        target: { slug: ['ethereum'] },
+      },
+    },
+  },
+}
+
+export const PartialWalletMovementAlert: Story = {
+  parameters: {},
+  args: {
+    alert: {
+      settings: {
+        type: 'wallet_movement',
+        target: { address: '0x123f123D2EFde0aD18B30b69acecC12dc3AB1f12' },
+        selector: { infrastructure: 'ETH' },
       },
     },
   },

--- a/src/stories/Design System - App UI/AlertsDialog/index.stories.ts
+++ b/src/stories/Design System - App UI/AlertsDialog/index.stories.ts
@@ -6,7 +6,7 @@ const meta = {
   parameters: {
     layout: 'fullscreen',
   },
-} satisfies Meta<component>
+} satisfies Meta<typeof component>
 type Story = StoryObj<typeof meta>
 
 export default meta
@@ -14,6 +14,9 @@ export default meta
 export const Empty: Story = {
   parameters: {},
 }
+
+const MOCK_SCREENER_ID = '36321'
+const MOCK_WATCHLIST_ID = 36415
 
 export const AssetAPIAlert: Story = {
   parameters: {},
@@ -92,7 +95,7 @@ export const WatchlistAPIAlert: Story = {
         type: 'metric_signal',
         template: null,
         target: {
-          watchlist_id: 1663,
+          watchlist_id: MOCK_WATCHLIST_ID,
         },
         operation: {
           some_of: [
@@ -129,11 +132,11 @@ export const ScreenerAPIAlert: Story = {
       settings: {
         type: 'screener_signal',
         target: {
-          watchlist_id: 669,
+          watchlist_id: MOCK_SCREENER_ID,
         },
         operation: {
           selector: {
-            watchlist_id: 669,
+            watchlist_id: MOCK_SCREENER_ID,
           },
         },
         channel: ['email', 'telegram'],
@@ -170,6 +173,50 @@ export const WalletAPIAlert: Story = {
         },
       },
       title: 'Balance goes below 1 compared to 1 day(s) earlier',
+    },
+  },
+}
+
+export const PartialTrendsAlert: Story = {
+  parameters: {},
+  args: {
+    alert: {
+      settings: {
+        type: 'trending_words',
+        target: {
+          word: ['bear', 'market'],
+        },
+        operation: {
+          trending_word: true,
+        },
+      },
+    },
+  },
+}
+
+export const PartialScreenerAlert: Story = {
+  parameters: {},
+  args: {
+    alert: {
+      settings: {
+        type: 'screener_signal',
+        metric: null,
+        target: { watchlist_id: MOCK_SCREENER_ID },
+        operation: { selector: { watchlist_id: MOCK_SCREENER_ID } },
+      },
+    },
+  },
+}
+
+export const PartialWatchlistAlert: Story = {
+  parameters: {},
+  args: {
+    alert: {
+      settings: {
+        type: 'metric_signal',
+        metric: null,
+        target: { watchlist_id: MOCK_WATCHLIST_ID },
+      },
     },
   },
 }

--- a/src/stories/Design System - App UI/AlertsDialog/index.stories.ts
+++ b/src/stories/Design System - App UI/AlertsDialog/index.stories.ts
@@ -18,7 +18,7 @@ export const Empty: Story = {
 export const AssetAPIAlert: Story = {
   parameters: {},
   args: {
-    apiAlert: {
+    alert: {
       cooldown: '2w',
       description:
         'Notify me when the price of Ethereum, Tether [on Ethereum] goes above 1$ compared to 1 day(s) earlier. Send me notifications every 1 day(s) via email.',
@@ -49,7 +49,7 @@ export const AssetAPIAlert: Story = {
 export const SocialTrendsAPIAlert: Story = {
   parameters: {},
   args: {
-    apiAlert: {
+    alert: {
       cooldown: '1d',
       description:
         'Notify me when the bear, market appears in social trends. Send me notifications every 1 day(s) via telegram.',
@@ -79,7 +79,7 @@ export const SocialTrendsAPIAlert: Story = {
 export const WatchlistAPIAlert: Story = {
   parameters: {},
   args: {
-    apiAlert: {
+    alert: {
       cooldown: '1m',
       description:
         'Notify me when the price of TestWatchlist moving up 20% or moving down 10% compared to 2 day(s) earlier. Send me notifications every 1 minute(s) via email.',
@@ -117,7 +117,7 @@ export const WatchlistAPIAlert: Story = {
 export const ScreenerAPIAlert: Story = {
   parameters: {},
   args: {
-    apiAlert: {
+    alert: {
       cooldown: '1m',
       description:
         'Notify me when any project enters/exits Stablecoins. Send me notifications every 1 minute(s) via email, telegram.',
@@ -146,7 +146,7 @@ export const ScreenerAPIAlert: Story = {
 export const WalletAPIAlert: Story = {
   parameters: {},
   args: {
-    apiAlert: {
+    alert: {
       cooldown: '1m',
       description: null,
       id: 2200,

--- a/src/stories/Design System - App UI/AlertsDialog/index.stories.ts
+++ b/src/stories/Design System - App UI/AlertsDialog/index.stories.ts
@@ -15,7 +15,7 @@ export const Empty: Story = {
   parameters: {},
 }
 
-const MOCK_SCREENER_ID = '36321'
+const MOCK_SCREENER_ID = 36321
 const MOCK_WATCHLIST_ID = 36415
 
 export const AssetAPIAlert: Story = {

--- a/src/stories/Design System - App UI/AlertsDialog/index.svelte
+++ b/src/stories/Design System - App UI/AlertsDialog/index.svelte
@@ -1,9 +1,14 @@
-<script>
+<script lang="ts">
   import { useAssetsCtx } from '$lib/ctx/assets/index.svelte.js'
   import AlertsDialog, { showAlertsDialog$ } from '$ui/app/Alerts/Dialog/index.js'
+  import type { TApiAlert } from '$ui/app/Alerts/types.js'
   import StoryDialog from '../../Design System - Core UI/Dialog/StoryDialog.svelte'
 
-  let { apiAlert } = $props()
+  type TProps = {
+    alert: Partial<TApiAlert>
+  }
+
+  let { alert }: TProps = $props()
 
   useAssetsCtx.set()
   const showAlertsDialog = showAlertsDialog$()
@@ -15,4 +20,4 @@
   </div>
 </div>
 
-<StoryDialog render={AlertsDialog} {apiAlert}></StoryDialog>
+<StoryDialog render={AlertsDialog} {alert}></StoryDialog>


### PR DESCRIPTION
## Summary

1. Rename `apiAlert` dialog prop to `alert` and make it `Partial` so alert could be created with some data prefilled. It's used in Sanbase to create alert for particular asset, watchlist, screener etc.
2. Fix some bugs found:
    - alert prop `id` was not passed to mutate function, so alert edit didn't work
    - Fix `watchlist_id` typings. It led to subtle bug with selected screener/watchlist did not appear selected
    - Fix bug with next step data leaking to previous step component (more on this below)
        - Pass only `step.state` to `Form` and `Legend` instead of whole `step` object
    - Fix padding inside `textarea` in `name-description` step
3. Make `Form` and `Legend` props types more strict

### Strange bug with props leaking

I found strange bug with next step info passed to previous step form on step change.
It caused just an exception. Maybe it's not big of a deal because component being destroyed right after exception occur, but theoretically it could lead to some subtle bug.

To fix it I just pass only `step.state` to `Form` component instead of whole `step` (other fields are not used anywhere). Another potential fix is extracting `state` from `step` inside `Form` component without `$derived` to prevent reactivity. I couldn't find more proper solution for this bug, maybe will research this later, outside the scope of this PR. 

Here is screenshot with exception. Both exception and `$inspect` were inside screener step. After step change, screener step component received `step` prop related to new step with different state without `screener` field, hence the exception

<img width="657" height="356" alt="Screenshot 2025-07-24 at 12 57 27" src="https://github.com/user-attachments/assets/0de7e542-331f-42d9-9e2e-931500867721" />

## Notion page
https://www.notion.so/santiment/Integrate-new-create-alert-dialog-to-Sanbase-23a2a82d1361801b9d09fd758aab4796?source=copy_link