### PR TITLE
refactor(alerts) Add return type for reduceToApi method

### DIFF
--- a/src/lib/ui/app/Alerts/Dialog/AlertFormScreen.svelte
+++ b/src/lib/ui/app/Alerts/Dialog/AlertFormScreen.svelte
@@ -5,13 +5,10 @@
   import Button from '$ui/core/Button/index.js'
   import { Query } from '$lib/api/executor.js'
   import { notification } from '$ui/core/Notifications/index.js'
-  import { useMetricsRestrictionsCtx } from '$lib/ctx/metrics-registry/index.js'
 
   import { useAlertFormCtx } from '../ctx/index.svelte.js'
   import Steps from './Steps.svelte'
   import { mutateSaveAlert } from './api.js'
-
-  type TReducedAlert = Omit<TApiAlert<{ type: string; target: object }>, 'id'>
 
   type TProps = {
     schema: TAlertSchemaUnion
@@ -22,8 +19,10 @@
   }
   let { schema, alert, resetCategory, close, onCreate }: TProps = $props()
 
-  const { steps, selectedStep, nextStep, isAlertValid } = useAlertFormCtx({ schema, alert })
-  const { MetricsRestrictions } = useMetricsRestrictionsCtx()
+  const { steps, selectedStep, nextStep, isAlertValid, reduceStepsToAlert } = useAlertFormCtx({
+    schema,
+    alert,
+  })
 
   let loading = $state(false)
 
@@ -33,7 +32,7 @@
   async function onAlertCreate() {
     try {
       loading = true
-      const reducedAlert = { ...createApiAlert(), id: alert?.id ?? null }
+      const reducedAlert = { ...reduceStepsToAlert(), id: alert?.id ?? null }
 
       const { id } = await mutateSaveAlert(Query)(reducedAlert)
 
@@ -47,37 +46,6 @@
     } finally {
       loading = false
     }
-  }
-
-  function createApiAlert() {
-    const apiAlert = steps.reduce(
-      (acc, step) => {
-        const state = $state.snapshot(step.state.$$) as typeof step.state.$$
-        return step.reduceToApi(acc, state as UnionToIntersection<typeof state>)
-      },
-      {
-        settings: {},
-      },
-    ) as TReducedAlert
-
-    const changedType = getChangedType(apiAlert.settings)
-    if (changedType && apiAlert.settings) {
-      apiAlert.settings.type = changedType
-    }
-
-    return apiAlert
-  }
-
-  function getChangedType(settings: TReducedAlert['settings']) {
-    if (settings?.type !== 'metric_signal') return null
-    if (!('metric' in settings) || typeof settings.metric !== 'string') return null
-
-    const minInterval = MetricsRestrictions.$[settings.metric]?.minInterval
-    if (minInterval === '1d') {
-      return 'daily_metric_signal'
-    }
-
-    return null
   }
 </script>
 

--- a/src/lib/ui/app/Alerts/categories/asset/asset-form-step/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/asset/asset-form-step/schema.ts
@@ -7,12 +7,7 @@ import Form from './ui/index.svelte'
 import Legend from './ui/Legend.svelte'
 
 // Declaring a type so it can be later used in Component's props
-export type TBaseSchema = TStepBaseSchema<
-  'assets',
-  {
-    initState: (apiAlert?: null | Partial<TAssetApiAlert>) => TAssetState
-  }
->
+export type TBaseSchema = TStepBaseSchema<'assets', TAssetApiAlert, TAssetState>
 
 export const STEP_ASSETS_SCHEMA = createStepSchema<TBaseSchema>({
   name: 'assets',
@@ -38,10 +33,7 @@ export const STEP_ASSETS_SCHEMA = createStepSchema<TBaseSchema>({
     return state.target.slugs.length > 0
   },
 
-  reduceToApi(apiAlert, state) {
-    Object.assign(apiAlert.settings, { type: 'metric_signal' })
-    Object.assign(apiAlert.settings, { target: { slug: state.target.slugs } })
-
-    return apiAlert
-  },
+  reduceToApi: (state) => ({
+    settings: { type: 'metric_signal', target: { slug: state.target.slugs } },
+  }),
 })

--- a/src/lib/ui/app/Alerts/categories/screener/screener-form-step/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/screener/screener-form-step/schema.ts
@@ -1,5 +1,7 @@
 import type { TScreenerApiAlert } from '../schema.js'
 
+import assert from 'assert'
+
 import { createStepSchema, type TStepBaseSchema } from '$ui/app/Alerts/form-steps/types.js'
 
 import Form from './ui/index.svelte'
@@ -13,12 +15,7 @@ export type TScreenerState = {
   }
 }
 
-export type TBaseSchema = TStepBaseSchema<
-  'screener',
-  {
-    initState: (apiAlert?: null | Partial<TScreenerApiAlert>) => TScreenerState
-  }
->
+export type TBaseSchema = TStepBaseSchema<'screener', TScreenerApiAlert, TScreenerState>
 
 export const STEP_SELECT_SCREENER_SCHEMA = createStepSchema<TBaseSchema>({
   name: 'screener',
@@ -42,17 +39,17 @@ export const STEP_SELECT_SCREENER_SCHEMA = createStepSchema<TBaseSchema>({
     return !!state.screener.id
   },
 
-  reduceToApi(apiAlert, { metric, screener }) {
-    Object.assign(apiAlert.settings, { type: 'screener_signal' })
-    Object.assign(apiAlert.settings, {
-      metric,
-      target: { watchlist_id: screener.id },
-    })
-    Object.assign(apiAlert.settings, {
-      operation: { selector: { watchlist_id: screener.id } },
-    })
+  reduceToApi({ metric, screener }) {
+    assert(screener.id, 'Screener is not selected')
 
-    return apiAlert
+    return {
+      settings: {
+        type: 'screener_signal',
+        metric,
+        target: { watchlist_id: screener.id },
+        operation: { selector: { watchlist_id: screener.id } },
+      },
+    }
   },
 })
 

--- a/src/lib/ui/app/Alerts/categories/social-trends/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/social-trends/schema.ts
@@ -8,23 +8,22 @@ import { getAssetTargetTitle } from '../asset/utils.js'
 export type TSocialTrendsApiAlert = TApiAlert<
   {
     type: 'trending_words'
-  } & (
-    | {
-        target: { slug: TAssetSlug[] }
-        operation: { trending_project: true }
-      }
-    | {
-        target: { word: string[] }
-        operation: { trending_word: true }
-      }
-    | {
-        target: { watchlist_id: string | number | null }
-        operation: { trending_project: true }
-      }
-  )
+  } & TSocialTrendsApiAlertTarget
 >
 
-export type TSocialTrendsApiAlertTarget = NonNullable<TSocialTrendsApiAlert['settings']>['target']
+export type TSocialTrendsApiAlertTarget =
+  | {
+      target: { slug: TAssetSlug[] }
+      operation: { trending_project: true }
+    }
+  | {
+      target: { word: string[] }
+      operation: { trending_word: true }
+    }
+  | {
+      target: { watchlist_id: string | number | null }
+      operation: { trending_project: true }
+    }
 
 export type TBaseSchema = TAlertBaseSchema<
   'social-trends',

--- a/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/schema.ts
@@ -28,12 +28,7 @@ export type TTrendState = {
 }
 
 // Declaring a type so it can be later used in Component's props
-export type TBaseSchema = TStepBaseSchema<
-  'select-trend',
-  {
-    initState: (apiAlert?: null | Partial<TSocialTrendsApiAlert>) => TTrendState
-  }
->
+export type TBaseSchema = TStepBaseSchema<'select-trend', TSocialTrendsApiAlert, TTrendState>
 
 export const STEP_SELECT_TREND_SCHEMA = createStepSchema<TBaseSchema>({
   name: 'select-trend',
@@ -64,17 +59,10 @@ export const STEP_SELECT_TREND_SCHEMA = createStepSchema<TBaseSchema>({
     return !!target.id
   },
 
-  reduceToApi(apiAlert, state) {
-    Object.assign(apiAlert.settings, { type: 'trending_words' })
-    Object.assign(apiAlert.settings, { target: getApiTarget(state.target) })
-    Object.assign(apiAlert.settings, { operation: { [getApiOperation(state)]: true } })
-
-    return apiAlert
-  },
+  reduceToApi: (state) => ({
+    settings: {
+      type: 'trending_words',
+      ...getApiTarget(state.target),
+    },
+  }),
 })
-
-function getApiOperation({ target }: TTrendState) {
-  if (target.type === 'word') return 'trending_word'
-
-  return 'trending_project'
-}

--- a/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/utils.ts
+++ b/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/utils.ts
@@ -12,25 +12,27 @@ export function getInitTrendTarget(type: TTrendState['target']['type']): TTrendS
   }
 }
 
-export function parseApiTarget(apiTarget: TSocialTrendsApiAlertTarget): TTrendState['target'] {
-  if ('slug' in apiTarget) {
-    return { type: 'asset', slugs: apiTarget.slug, namesMap: new Map() }
+export function parseApiTarget(
+  target: TSocialTrendsApiAlertTarget['target'],
+): TTrendState['target'] {
+  if ('slug' in target) {
+    return { type: 'asset', slugs: target.slug, namesMap: new Map() }
   }
 
-  if ('word' in apiTarget) {
-    return { type: 'word', words: apiTarget.word }
+  if ('word' in target) {
+    return { type: 'word', words: target.word }
   }
 
-  return { type: 'watchlist', id: apiTarget.watchlist_id?.toString() ?? null, title: '' }
+  return { type: 'watchlist', id: target.watchlist_id?.toString() ?? null, title: '' }
 }
 
 export function getApiTarget(target: TTrendState['target']): TSocialTrendsApiAlertTarget {
   switch (target.type) {
     case 'asset':
-      return { slug: target.slugs }
+      return { target: { slug: target.slugs }, operation: { trending_project: true } }
     case 'word':
-      return { word: target.words }
+      return { target: { word: target.words }, operation: { trending_word: true } }
     case 'watchlist':
-      return { watchlist_id: target.id }
+      return { target: { watchlist_id: target.id }, operation: { trending_project: true } }
   }
 }

--- a/src/lib/ui/app/Alerts/categories/wallet/wallet-form-step/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/wallet/wallet-form-step/schema.ts
@@ -1,6 +1,8 @@
 import type { TWalletApiAlert } from '../schema.js'
 import type { TMetricConditionsState } from '$ui/app/Alerts/form-steps/metric-conditions/schema.js'
 
+import assert from 'assert'
+
 import { createStepSchema, type TStepBaseSchema } from '$ui/app/Alerts/form-steps/types.js'
 import {
   getOperationFromApi,
@@ -22,12 +24,7 @@ export type TWalletState = {
   conditions: TMetricConditionsState['conditions'] | null
 }
 
-export type TBaseSchema = TStepBaseSchema<
-  'wallet',
-  {
-    initState: (apiAlert?: null | Partial<TWalletApiAlert>) => TWalletState
-  }
->
+export type TBaseSchema = TStepBaseSchema<'wallet', TWalletApiAlert, TWalletState>
 
 export const STEP_SELECT_WALLET_SCHEMA = createStepSchema<TBaseSchema>({
   name: 'wallet',
@@ -87,18 +84,24 @@ export const STEP_SELECT_WALLET_SCHEMA = createStepSchema<TBaseSchema>({
     }
   },
 
-  reduceToApi(apiAlert, { target, type, conditions, asset }) {
-    Object.assign(apiAlert.settings, {
-      target,
-      type,
-      selector: {
-        infrastructure: target?.infrastructure,
-        slug: asset?.slug,
-      },
-      time_window: conditions?.time,
-      operation: conditions?.operation && reduceOperationToApi(conditions.operation),
-    })
+  reduceToApi({ target, type, conditions, asset }) {
+    assert(type)
+    assert(target.address)
+    assert(target.infrastructure)
 
-    return apiAlert
+    return {
+      settings: {
+        type,
+        target: {
+          address: target.address,
+        },
+        selector: {
+          infrastructure: target.infrastructure,
+          slug: asset?.slug,
+        },
+        time_window: conditions?.time,
+        operation: conditions?.operation && reduceOperationToApi(conditions.operation),
+      },
+    }
   },
 })

--- a/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/schema.ts
@@ -1,17 +1,14 @@
 import type { TWatchlistApiAlert } from '../schema.js'
 import type { TWatchlistState } from './state.js'
 
+import assert from 'assert'
+
 import { createStepSchema, type TStepBaseSchema } from '$ui/app/Alerts/form-steps/types.js'
 
 import Form from './ui/index.svelte'
 import Legend from './ui/Legend.svelte'
 
-export type TBaseSchema = TStepBaseSchema<
-  'watchlist',
-  {
-    initState: (apiAlert?: null | Partial<TWatchlistApiAlert>) => TWatchlistState
-  }
->
+export type TBaseSchema = TStepBaseSchema<'watchlist', TWatchlistApiAlert, TWatchlistState>
 
 export const STEP_SELECT_WATCHLIST_SCHEMA = createStepSchema<TBaseSchema>({
   name: 'watchlist',
@@ -37,10 +34,16 @@ export const STEP_SELECT_WATCHLIST_SCHEMA = createStepSchema<TBaseSchema>({
     return !!state.watchlist.id
   },
 
-  reduceToApi(apiAlert, state) {
-    Object.assign(apiAlert.settings, { type: 'metric_signal' })
-    Object.assign(apiAlert.settings, { target: { watchlist_id: state.watchlist.id } })
+  reduceToApi(state) {
+    assert(state.watchlist.id)
 
-    return apiAlert
+    return {
+      settings: {
+        type: 'metric_signal',
+        target: {
+          watchlist_id: state.watchlist.id,
+        },
+      },
+    }
   },
 })

--- a/src/lib/ui/app/Alerts/ctx/index.svelte.ts
+++ b/src/lib/ui/app/Alerts/ctx/index.svelte.ts
@@ -1,14 +1,19 @@
 import type { TAlertSchemaUnion } from '../categories/index.js'
-import type { TApiAlert } from '../types.js'
+import type { TApiAlert, TGenericSettings } from '../types.js'
 
 import { createCtx } from '$lib/utils/index.js'
+import { useMetricsRestrictionsCtx } from '$lib/ctx/metrics-registry/index.js'
 
 import { createAlertStep } from '../form-steps/index.svelte.js'
+
+export type TReducedAlert = Omit<TApiAlert<TGenericSettings>, 'id'>
 
 export const useAlertFormCtx = createCtx(
   'alerts_useAlertFormCtx',
   ({ schema, alert }: { schema: TAlertSchemaUnion; alert?: null | Partial<TApiAlert> }) => {
     const steps = schema.steps.map((step) => createAlertStep(alert, step))
+
+    const { MetricsRestrictions } = useMetricsRestrictionsCtx()
 
     let selectedIndex = $state(0)
     const selectedStep = $derived(steps[selectedIndex])
@@ -16,11 +21,45 @@ export const useAlertFormCtx = createCtx(
 
     const isAlertValid = $derived(steps.every((step) => step.isValid.$))
 
+    function reduceStepsToAlert() {
+      const apiAlert = steps.reduce((acc, step) => {
+        const state = $state.snapshot(step.state.$$) as typeof step.state.$$
+
+        const stepAlertPart = step.reduceToApi(state as UnionToIntersection<typeof state>)
+
+        return {
+          ...acc,
+          ...stepAlertPart,
+          settings: { ...acc.settings, ...stepAlertPart.settings },
+        }
+      }, {} as TReducedAlert)
+
+      const changedType = getChangedAlertType(apiAlert.settings)
+      if (changedType && apiAlert.settings) {
+        apiAlert.settings.type = changedType
+      }
+
+      return apiAlert
+    }
+
+    function getChangedAlertType(settings: TGenericSettings) {
+      if (settings?.type !== 'metric_signal') return null
+      if (!('metric' in settings) || typeof settings.metric !== 'string') return null
+
+      const minInterval = MetricsRestrictions.$[settings.metric]?.minInterval
+      if (minInterval === '1d') {
+        return 'daily_metric_signal'
+      }
+
+      return null
+    }
+
     return {
       schema: schema as TAlertSchemaUnion & {
         suggestTitle: (_steps: typeof steps) => Promise<string> | string
         suggestDescription: (_steps: typeof steps) => Promise<string> | string
       },
+      reduceStepsToAlert,
       steps,
       selectedStep: {
         get $() {

--- a/src/lib/ui/app/Alerts/form-steps/index.svelte.ts
+++ b/src/lib/ui/app/Alerts/form-steps/index.svelte.ts
@@ -34,7 +34,7 @@ export function createAlertStep<GStepSchema extends TStepSchema>(
 }
 
 export type TBaseState<
-  GStepSchema extends TStepBaseSchema<string, any> = TStepBaseSchema<string, any>,
+  GStepSchema extends TStepBaseSchema<string, any, any> = TStepBaseSchema<string, any, any>,
 > = {
   get $$(): IfAny<
     ReturnType<GStepSchema['initState']>,
@@ -52,7 +52,7 @@ export type TBaseState<
 }
 
 export type TAlertStep<
-  GStepSchema extends TStepBaseSchema<string, any> = TStepBaseSchema<string, any>,
+  GStepSchema extends TStepBaseSchema<string, any, any> = TStepBaseSchema<string, any, any>,
 > = {
   name: GStepSchema['name']
   ui: TStepUI<{ state: TBaseState<GStepSchema> }>['ui']

--- a/src/lib/ui/app/Alerts/form-steps/name-description/schema.ts
+++ b/src/lib/ui/app/Alerts/form-steps/name-description/schema.ts
@@ -10,12 +10,7 @@ export type TNameDescriptionState = {
 }
 
 // Declaring a type so it can be later used in Component's props
-export type TBaseSchema = TStepBaseSchema<
-  'name-description',
-  {
-    initState: (apiAlert?: null | Partial<TApiAlert>) => TNameDescriptionState
-  }
->
+export type TBaseSchema = TStepBaseSchema<'name-description', TApiAlert, TNameDescriptionState>
 
 export const STEP_NAME_DESCRIPTION_SCHEMA = createStepSchema<TBaseSchema>({
   name: 'name-description',
@@ -39,9 +34,5 @@ export const STEP_NAME_DESCRIPTION_SCHEMA = createStepSchema<TBaseSchema>({
     return !!state.title
   },
 
-  reduceToApi(apiAlert, state) {
-    Object.assign(apiAlert, state)
-
-    return apiAlert
-  },
+  reduceToApi: ({ title, description }) => ({ title, description }),
 })

--- a/src/lib/ui/app/Alerts/form-steps/notifications-privacy/schema.ts
+++ b/src/lib/ui/app/Alerts/form-steps/notifications-privacy/schema.ts
@@ -13,12 +13,7 @@ export type TNotificationsState = {
   cooldown: TTimeWindow
 }
 
-export type TBaseSchema = TStepBaseSchema<
-  'notifications-privacy',
-  {
-    initState: (apiAlert?: null | Partial<TApiAlert<unknown>>) => TNotificationsState
-  }
->
+export type TBaseSchema = TStepBaseSchema<'notifications-privacy', TApiAlert, TNotificationsState>
 
 export const STEP_NOTIFICATIONS_PRIVACY_SCHEMA = createStepSchema<TBaseSchema>({
   name: 'notifications-privacy',
@@ -45,12 +40,12 @@ export const STEP_NOTIFICATIONS_PRIVACY_SCHEMA = createStepSchema<TBaseSchema>({
     return Object.values(state.channel).some((value) => !!value)
   },
 
-  reduceToApi(apiAlert, state) {
-    const { channel, ...rest } = state
-
-    Object.assign(apiAlert, rest)
-    Object.assign(apiAlert.settings, { channel: reduceChannelToApi(channel) })
-
-    return apiAlert
-  },
+  reduceToApi: ({ channel, isRepeating, isPublic, cooldown }) => ({
+    isPublic,
+    isRepeating,
+    cooldown,
+    settings: {
+      channel: reduceChannelToApi(channel),
+    },
+  }),
 })

--- a/src/lib/ui/app/Alerts/form-steps/types.ts
+++ b/src/lib/ui/app/Alerts/form-steps/types.ts
@@ -1,23 +1,20 @@
 import type { Component } from 'svelte'
 import type { TApiAlert } from '../types.js'
 import type { TBaseState } from './index.svelte.js'
+import type { DeepPartial } from '$lib/utils/types/index.js'
 
 export type TStepBaseSchema<
   GName,
-  GProps extends {
-    initState: (apiAlert?: null | Partial<TApiAlert>) => { [key: string]: unknown }
-  },
+  GAlert extends TApiAlert,
+  GState extends { [key: string]: unknown },
 > = {
   name: GName
 
-  initState: GProps['initState']
+  initState: (apiAlert?: null | Partial<GAlert>) => GState
 
-  validate: (state: ReturnType<GProps['initState']>) => boolean
+  validate: (state: GState) => boolean
 
-  reduceToApi: (
-    apiAlert: { settings: object },
-    state: ReturnType<GProps['initState']>,
-  ) => { settings: object }
+  reduceToApi: (state: GState) => DeepPartial<GAlert>
 }
 
 export type TStepUI<GState extends Record<string, any>> = {
@@ -31,15 +28,9 @@ export type TStepUI<GState extends Record<string, any>> = {
   }
 }
 
-export type TStepSchema = TStepBaseSchema<
-  string,
-  {
-    initState: (apiAlert?: null | Partial<TApiAlert>) => any
-  }
-> &
-  TStepUI<any>
+export type TStepSchema = TStepBaseSchema<string, TApiAlert, any> & TStepUI<any>
 
-export function createStepSchema<GBaseSchema extends TStepBaseSchema<string, any> = any>(
+export function createStepSchema<GBaseSchema extends TStepBaseSchema<string, any, any> = any>(
   base: GBaseSchema & TStepUI<{ state: TBaseState<GBaseSchema> }>,
 ) {
   const schema = {

--- a/src/lib/ui/app/Alerts/types.ts
+++ b/src/lib/ui/app/Alerts/types.ts
@@ -1,12 +1,20 @@
 import type { TApiChannel } from './channels.js'
 import type { TAPITimeWindow } from './time.js'
 
-export type TApiAlert<GSettings = any> = {
-  id: number
+export type TGenericSettings = {
   type: string
+  target: unknown
+  operation?: unknown
+  selector?: object
+  time_window?: TAPITimeWindow
+  metric?: string
+}
 
-  description: null | string
+export type TApiAlert<GSettings extends Partial<TGenericSettings> = any> = {
+  id: number
+
   title: string
+  description: null | string
 
   cooldown: TAPITimeWindow
 
@@ -15,9 +23,7 @@ export type TApiAlert<GSettings = any> = {
   isPublic: boolean
   isRepeating: boolean
 
-  settings:
-    | null
-    | ({
-        channel: TApiChannel | TApiChannel[]
-      } & GSettings)
+  settings: {
+    channel: TApiChannel[]
+  } & GSettings
 }

--- a/src/lib/utils/types/index.ts
+++ b/src/lib/utils/types/index.ts
@@ -5,3 +5,11 @@ export type IfAny<T, Y, N> = 0 extends 1 & T ? Y : N
 export type NonNullableProperties<T> = {
   [K in keyof T]-?: NonNullable<T[K]>
 }
+
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends (infer U)[]
+    ? DeepPartial<U>[]
+    : T[P] extends readonly (infer X)[]
+      ? readonly DeepPartial<X>[]
+      : DeepPartial<T[P]>
+}


### PR DESCRIPTION
## Summary

Proposal for update alerts and steps types

1. Change signature of `reduceToApi` method of step
  - Remove `apiAlert` parameter
  - Add generic return type of `DeepPartial` version of step's api alert type
  - Returns part api alert instead of mutation some alert object
2. `createApiAlert` (now `reduceStepsToAlert`) combines all parts of steps' alerts to one alert. Function moved to `useAlertFormCtx`
3. Update signature if `TStepBaseSchema` type. Now accepts `GAlert` and `GState` type parameters instead of `GProps` object

Notes:
- There are still some `any`s here and there. So there are could be potential place with misleading types. No new `any`s though
- `reduceToApi` has loose return type. It cannot catch missing property for example. However it provides autocompletion and generic object structure