### PR TITLE
fix(alerts) Deselect deleted screener or watchlist on alert open preventing to update alert without selecting another watchlist

### DIFF
--- a/src/lib/ui/app/Alerts/categories/watchlist/data.svelte.ts
+++ b/src/lib/ui/app/Alerts/categories/watchlist/data.svelte.ts
@@ -10,6 +10,7 @@ export const useUserWatchlistsCtx = createCtx(
   'webkit_useUserWatchlistsCtx',
   ({ loadScreeners = false }: { loadScreeners?: boolean } = {}) => {
     let watchlists = $state<Watchlist[]>([])
+    let loaded = $state(false)
 
     const watchlistsMap = $derived(
       new Map(watchlists.map((watchlist) => [watchlist.id, watchlist])),
@@ -20,6 +21,7 @@ export const useUserWatchlistsCtx = createCtx(
         switchMap(() => queryUserWatchlists()()),
         map((watchlists) => watchlists.filter(({ isScreener }) => loadScreeners === isScreener)),
         tap((_watchlists) => (watchlists = _watchlists)),
+        tap(() => (loaded = true)),
       ),
     )
 
@@ -29,6 +31,10 @@ export const useUserWatchlistsCtx = createCtx(
       watchlists: {
         get $() {
           return watchlists
+        },
+
+        get loaded$() {
+          return loaded
         },
       },
 

--- a/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/ui/ListOfWatchlists.svelte
+++ b/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/ui/ListOfWatchlists.svelte
@@ -26,6 +26,15 @@
 
   const filteredWatchlists = $derived(filter(watchlists.$))
 
+  $effect(() => {
+    if (!watchlists.loaded$) return
+
+    const selectedInList = !!watchlists.$.find(({ id }) => selectedId === id)
+    if (!selectedInList) {
+      onSelect(null)
+    }
+  })
+
   onMount(() => {
     return () => clear()
   })


### PR DESCRIPTION
## Summary
Deselect deleted screener or watchlist on alert open preventing to update alert without selecting another watchlist