### PR TITLE
Fix/alerts bugs2

### DIFF
--- a/src/lib/ui/app/Alerts/categories/wallet/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/wallet/schema.ts
@@ -15,7 +15,7 @@ export const WalletAlertTypes = [
 export type TWalletAlertType = (typeof WalletAlertTypes)[number]
 
 export type TWalletApiAlert = TApiAlert<{
-  target: { address: string }
+  target: { address: string | string[] }
   type: TWalletAlertType
   selector: { infrastructure?: string; slug?: string }
   operation?: TApiOperation

--- a/src/lib/ui/app/Alerts/categories/wallet/wallet-form-step/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/wallet/wallet-form-step/schema.ts
@@ -16,7 +16,7 @@ type TWalletSettings = NonNullable<TWalletApiAlert['settings']>
 
 export type TWalletState = {
   target: {
-    address: TWalletSettings['target']['address'] | null
+    address: string | null
     readonly infrastructure: Infrastructure | undefined
   }
   asset: { slug: string; name: string } | null
@@ -49,7 +49,7 @@ export const STEP_SELECT_WALLET_SCHEMA = createStepSchema<TBaseSchema>({
 
     return {
       target: {
-        address: target?.address ?? null,
+        address: Array.isArray(target?.address) ? target.address[0] : (target?.address ?? null),
         get infrastructure() {
           return getAddressInfrastructure(this.address ?? '')
         },

--- a/src/lib/ui/app/Alerts/categories/wallet/wallet-form-step/ui/SelectAsset.svelte
+++ b/src/lib/ui/app/Alerts/categories/wallet/wallet-form-step/ui/SelectAsset.svelte
@@ -53,7 +53,7 @@
   {/snippet}
 
   {#snippet content({ close })}
-    <section class="flex h-96 flex-col gap-2">
+    <section class="flex flex-col gap-2">
       <Input
         icon="search"
         oninput={onInput}
@@ -63,7 +63,7 @@
       />
 
       <section class="flex-1">
-        <VirtualList itemHeight={32} data={filtered} getKey={(slug) => slug}>
+        <VirtualList itemHeight={30} maxHeight={335} data={filtered} getKey={(slug) => slug}>
           {#snippet children(slug)}
             {@const item = getAssetBySlug(slug)}
 

--- a/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/schema.ts
@@ -41,7 +41,7 @@ export const STEP_SELECT_WATCHLIST_SCHEMA = createStepSchema<TBaseSchema>({
       settings: {
         type: 'metric_signal',
         target: {
-          watchlist_id: state.watchlist.id,
+          watchlist_id: +state.watchlist.id,
         },
       },
     }

--- a/src/stories/Design System - App UI/AlertsDialog/index.stories.ts
+++ b/src/stories/Design System - App UI/AlertsDialog/index.stories.ts
@@ -177,6 +177,37 @@ export const WalletAPIAlert: Story = {
   },
 }
 
+export const WalletArrayTargetAPIAlert: Story = {
+  parameters: {},
+  args: {
+    alert: {
+      cooldown: '1m',
+      description: null,
+      id: 2200,
+      isActive: true,
+      isFrozen: false,
+      isPublic: false,
+      isRepeating: true,
+      settings: {
+        type: 'wallet_movement',
+        target: {
+          address: ['0x123f123D2EFde0aD18B30b69acecC12dc3AB1f12'],
+        },
+        operation: {
+          below: 1,
+        },
+        channel: ['email'],
+        time_window: '1d',
+        selector: {
+          slug: 'ethereum',
+          infrastructure: 'ETH',
+        },
+      },
+      title: 'Balance goes below 1 compared to 1 day(s) earlier',
+    },
+  },
+}
+
 export const PartialTrendsAlert: Story = {
   parameters: {},
   args: {


### PR DESCRIPTION
## Summary

1. `watchlist` alert api did not accept `string` `watchlist_id`, converted it to `number` in `reduceToApi`. To summarize: `getWatchlists` (screeners also fall to this) query returns items with `string` ids, `screener` alert api accepts `watchlist_id` with `string` or `number` type (currently it's sent as `string`), `watchlist` alert support only `number` `watchlist_id`; all alerts' settings saved as is 

2. Add support for array of wallet addresses from api. The array is converted to string (first item is taken) and send to api as plain string. It's ok as our UI currently supports only one wallet per alert

3. Fix asset selector height with low number of assets