### PR TITLE
fix(alerts) Convert watchlist_id for trend alert to number in reduceToApi

### DIFF
--- a/src/lib/ui/app/Alerts/categories/social-trends/schema.ts
+++ b/src/lib/ui/app/Alerts/categories/social-trends/schema.ts
@@ -21,7 +21,7 @@ export type TSocialTrendsApiAlertTarget =
       operation: { trending_word: true }
     }
   | {
-      target: { watchlist_id: string | number | null }
+      target: { watchlist_id: number | null }
       operation: { trending_project: true }
     }
 

--- a/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/utils.ts
+++ b/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/utils.ts
@@ -33,6 +33,9 @@ export function getApiTarget(target: TTrendState['target']): TSocialTrendsApiAle
     case 'word':
       return { target: { word: target.words }, operation: { trending_word: true } }
     case 'watchlist':
-      return { target: { watchlist_id: target.id }, operation: { trending_project: true } }
+      return {
+        target: { watchlist_id: target.id ? +target.id : null },
+        operation: { trending_project: true },
+      }
   }
 }


### PR DESCRIPTION
## Summary

Convert`watchlist_id` in trend alert to `number` in `reduceToApi` before sending to backend

## Notion card
https://www.notion.so/santiment/Integrate-new-create-alert-dialog-to-Sanbase-23a2a82d1361801b9d09fd758aab4796?source=copy_link