### PR TITLE
Fix/nav header styles

### DIFF
--- a/src/lib/ui/app/AccountDropdown/AccountDropdown.svelte
+++ b/src/lib/ui/app/AccountDropdown/AccountDropdown.svelte
@@ -32,7 +32,7 @@
   }
 </script>
 
-<Tooltip class="z-[100] w-[240px] divide-y overflow-auto p-0 column">
+<Tooltip class="z-[100] w-[240px] divide-y overflow-auto p-0 text-fiord column">
   {#snippet children({ ref })}
     <ProfilePicture class={className} {ref}></ProfilePicture>
   {/snippet}

--- a/src/lib/ui/app/AccountDropdown/AccountDropdown.svelte
+++ b/src/lib/ui/app/AccountDropdown/AccountDropdown.svelte
@@ -9,6 +9,7 @@
   import Tooltip from '$ui/core/Tooltip/index.js'
   import { useLogoutFlow } from '$lib/flow/logout/index.js'
   import { SANBASE_ORIGIN } from '$lib/utils/links.js'
+  import { cn } from '$ui/utils/index.js'
 
   import ProfilePicture from './ProfilePicture.svelte'
   import AccountInfo from './AccountInfo.svelte'
@@ -41,19 +42,17 @@
     {#if currentUser.$$}
       <AccountInfo></AccountInfo>
 
-      <section>
-        <div class="px-2.5">
-          Version: <span class="text-waterloo">{version}</span>
-        </div>
+      <section class="px-5 py-2.5">
+        Version: <span class="text-waterloo">{version}</span>
       </section>
 
-      <section>
+      <section class="flex flex-col gap-1 px-3 py-1">
         {@render sanbaseLink('My profile', `/profile/${currentUser.$$.id}`)}
 
         {@render sanbaseLink('Account settings', '/account')}
       </section>
 
-      <section>
+      <section class="flex flex-col gap-1 px-3 pb-2.5 pt-2">
         {@render sanbaseLink('My alerts', '/alerts')}
 
         {@render sanbaseLink('My watchlists', '/watchlists')}
@@ -62,11 +61,11 @@
 
         {@render sanbaseLink('Write insight', '/insights/new', {
           variant: 'fill',
-          class: 'ml-2.5 w-max',
+          class: 'ml-2.5 w-max px-5',
         })}
       </section>
     {:else}
-      <section>
+      <section class="flex flex-col px-3 py-2.5">
         {@render sanbaseLink('Sign up', '/sign-up', {
           icon: 'user',
           class: 'fill-green text-green',
@@ -74,7 +73,7 @@
       </section>
     {/if}
 
-    <section>
+    <section class="flex flex-col gap-1 px-3 py-2.5">
       <Button as="label" variant="ghost" class="justify-between">
         Night mode
         <Switch checked={ui.$$.isNightMode} onCheckedChange={ui.toggleNightMode}></Switch>
@@ -98,14 +97,18 @@
   {/snippet}
 </Tooltip>
 
-{#snippet sanbaseLink(text: string, href: string, props: ComponentProps<typeof Button> = {})}
-  <Button variant="ghost" {...props} href={SANBASE_ORIGIN + href} data-source="account_dropdown">
+{#snippet sanbaseLink(
+  text: string,
+  href: string,
+  { class: className, ...props }: ComponentProps<typeof Button> = {},
+)}
+  <Button
+    variant="ghost"
+    class={cn('px-2', className)}
+    {...props}
+    href={SANBASE_ORIGIN + href}
+    data-source="account_dropdown"
+  >
     {text}
   </Button>
 {/snippet}
-
-<style lang="postcss">
-  section {
-    @apply gap-0.5 px-3 py-2.5 column;
-  }
-</style>

--- a/src/lib/ui/app/AccountDropdown/AccountInfo.svelte
+++ b/src/lib/ui/app/AccountDropdown/AccountInfo.svelte
@@ -21,10 +21,7 @@
       <ProfilePicture as="div" class="min-w-8"></ProfilePicture>
 
       <div class="min-w-0 single-line">
-        <a
-          href={SANBASE_ORIGIN + '/profile/' + currentUser.$$.id}
-          class="font-medium text-rhino link-as-bg"
-        >
+        <a href={SANBASE_ORIGIN + '/profile/' + currentUser.$$.id} class="font-medium link-as-bg">
           @{currentUser.$$.username}
         </a>
 

--- a/src/lib/ui/app/AccountDropdown/AccountInfo.svelte
+++ b/src/lib/ui/app/AccountDropdown/AccountInfo.svelte
@@ -12,7 +12,7 @@
   {@const { planName, isEligibleForSanbaseTrial, trialDaysLeft, isTrialSubscription } = customer.$}
   {@const { isFree, isCustom, isBusinessSubscription } = customer.$}
   <section
-    class="gap-2 px-[22px] pb-[14px] pt-4 column"
+    class="gap-2 px-5 pb-[14px] pt-4 column"
     style={isBusinessSubscription
       ? '--c-orange:var(--c-blue);--c-orange-hover:var(--c-blue-hover)'
       : ''}

--- a/src/lib/ui/core/Tooltip/Tooltip.svelte
+++ b/src/lib/ui/core/Tooltip/Tooltip.svelte
@@ -6,6 +6,8 @@
   import { cn, flyAndScale } from '$ui/utils/index.js'
   import { useMelt } from '$ui/utils/melt-ui.js'
 
+  type FloatingConfig = NonNullable<CreateTooltipProps['positioning']>
+
   type TooltipType = 'plain' | 'arrow'
   type Props = {
     class?: string
@@ -14,7 +16,8 @@
     type?: TooltipType
     children: Snippet<[{ ref: typeof triggerRef }]>
     content: Snippet<[{ close: () => void }]>
-    position?: NonNullable<CreateTooltipProps['positioning']>['placement']
+    position?: FloatingConfig['placement']
+    offset?: number
   } & Omit<CreateTooltipProps, 'positioning'>
 
   let {
@@ -25,6 +28,7 @@
     type = 'plain',
     isOpened = false,
     position = 'bottom-end',
+    offset,
     ...options
   }: Props = $props()
 
@@ -41,6 +45,10 @@
     positioning: {
       placement: position,
       fitViewport: true,
+      // NOTE: [gutter] must be set to 0 in order to offset to work
+      gutter: offset ? 0 : 5,
+      // NOTE: [mainAxis] is here to compensate zero gutter. 5 is the default [gutter] value
+      offset: offset ? { mainAxis: 5, crossAxis: offset } : undefined,
     },
   })
 

--- a/src/lib/ui/core/Tooltip/Tooltip.svelte
+++ b/src/lib/ui/core/Tooltip/Tooltip.svelte
@@ -18,6 +18,7 @@
     content: Snippet<[{ close: () => void }]>
     position?: FloatingConfig['placement']
     offset?: number
+    positionConfig?: FloatingConfig
   } & Omit<CreateTooltipProps, 'positioning'>
 
   let {
@@ -28,6 +29,7 @@
     type = 'plain',
     isOpened = false,
     position = 'bottom-end',
+    positionConfig,
     offset,
     ...options
   }: Props = $props()
@@ -49,6 +51,7 @@
       gutter: offset ? 0 : 5,
       // NOTE: [mainAxis] is here to compensate zero gutter. 5 is the default [gutter] value
       offset: offset ? { mainAxis: 5, crossAxis: offset } : undefined,
+      ...positionConfig,
     },
   })
 

--- a/src/stories/Design System - Core UI/Tooltip/PositionedTooltip.svelte
+++ b/src/stories/Design System - Core UI/Tooltip/PositionedTooltip.svelte
@@ -1,0 +1,21 @@
+<script>
+  import Button from '$ui/core/Button/Button.svelte'
+  import Tooltip from '$ui/core/Tooltip/Tooltip.svelte'
+</script>
+
+<main class="flex justify-center py-40">
+  <Tooltip position="bottom-start" offset={-24} positionConfig={{ sameWidth: true }}>
+    {#snippet children({ ref })}
+      <Button variant="border" {ref}>Long Trigger Button</Button>
+    {/snippet}
+
+    {#snippet content()}
+      <section>
+        Here is some content for our Tooltip with text that is somewhat long.
+        <br />
+        Width of content is the same as trigger button. There is also <strong>24px</strong> offset on
+        cross axis
+      </section>
+    {/snippet}
+  </Tooltip>
+</main>

--- a/src/stories/Design System - Core UI/Tooltip/index.stories.ts
+++ b/src/stories/Design System - Core UI/Tooltip/index.stories.ts
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/svelte'
 import type { Component, ComponentProps } from 'svelte'
 
 import component from './index.svelte'
+import PositionedTooltip from './PositionedTooltip.svelte'
 
 const meta = {
   component,
@@ -14,3 +15,9 @@ type Story = StoryObj<typeof meta>
 export default meta
 
 export const Tooltip: Story = {}
+
+export const TooltipWithPostitionConfig: StoryObj<typeof PositionedTooltip> = {
+  render: () => ({
+    Component: PositionedTooltip,
+  }),
+}


### PR DESCRIPTION
## Summary

1. Update styles of `AccountDropdown`
2. Add `offset` prop (overrides `crossAxis` offset) and `positionConfig` (is merged with default `positioning`) to `Tooltip` component
  - The `gutter` props in `positioning` must be set to `0` in order to `offset` prop to work

## Notion card
https://www.notion.so/santiment/Sanbase-navbar-visual-issues-2482a82d136180f4b0acf57bc9164543?source=copy_link

## Screenshots
<img width="287" height="597" alt="image" src="https://github.com/user-attachments/assets/0b18511d-851e-4f95-ad0e-dc360cf348ba" />
