### PR TITLE
feat(analytics): added event legacy support

### DIFF
--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -74,6 +74,10 @@ const event: SendEvent = isTrackingEnabled
         )
       }
 
+      if (BROWSER) {
+        window.__trackLegacyWebkitEvent(action, { category, label, ...rest })
+      }
+
       if (trackers.includes(Tracker.AMPLITUDE) && window.amplitude && window.amplitude.track) {
         window.amplitude.track(
           action,

--- a/src/analytics/index.ts
+++ b/src/analytics/index.ts
@@ -7,7 +7,6 @@ export enum Tracker {
   GA = 'ga',
   SAN = 'san',
   TWQ = 'twq',
-  AMPLITUDE = 'AMPLITUDE',
 }
 
 const noop = () => {} // eslint-disable-line
@@ -21,7 +20,7 @@ function canTrackBrowser() {
 export const isTrackingEnabled =
   BROWSER && (process.env.IS_DEV_MODE || (process.env.IS_PROD_BACKEND ? canTrackBrowser() : true))
 
-const DEFAULT_TRACKERS = [Tracker.GA, Tracker.SAN, Tracker.AMPLITUDE]
+const DEFAULT_TRACKERS = [Tracker.GA, Tracker.SAN]
 
 export type EventData = {
   [key: string]: undefined | string | number | string[] | number[] | boolean | boolean[]
@@ -76,19 +75,6 @@ const event: SendEvent = isTrackingEnabled
 
       if (BROWSER) {
         window.__trackLegacyWebkitEvent(action, { category, label, ...rest })
-      }
-
-      if (trackers.includes(Tracker.AMPLITUDE) && window.amplitude && window.amplitude.track) {
-        window.amplitude.track(
-          action,
-          normalizeData({
-            event_category: category,
-            event_label: label,
-            ...rest,
-          }),
-        )
-        // NOTE: Was causing issues, since was called before amplitude's internal config init
-        // window.amplitude.flush()
       }
 
       return date

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -1,3 +1,5 @@
+import type { EventData } from '@/analytics'
+
 declare module 'svelte/internal'
 
 declare namespace NodeJS {
@@ -27,6 +29,7 @@ interface Window {
   twq?: any
   __SAPPER__?: any
   __SESSION__?: any
+  __trackLegacyWebkitEvent?: (eventName: string, data?: EventData) => void
 
   amplitude?: {
     track: (action: string, eventProperties: { [key: string]: any }) => void


### PR DESCRIPTION
### Description

1. Added bridge for legacy events support (Part 1)

### Notion's task

https://www.notion.so/santiment/Remove-all-amplitude-trackers-and-add-posthog-24c2a82d1361801888b5c12204b6e7cd?source=copy_link