### PR TITLE
feat(button) Add new rounded variant

### DIFF
--- a/src/lib/ui/core/Button/Button.svelte
+++ b/src/lib/ui/core/Button/Button.svelte
@@ -43,6 +43,7 @@
     size: initialSize,
     iconOnRight = false,
     rounded = false,
+    circle = false,
     loading = false,
 
     icon,
@@ -65,7 +66,7 @@
   const iconSize = $derived(initialIconSize ?? (size === 'md' || size === 'lg' ? 16 : 12))
 
   const button = tv({
-    base: 'flex items-center cursor-pointer gap-2 rounded-md',
+    base: 'flex transition-colors items-center cursor-pointer gap-2 rounded-md',
     variants: {
       children: { false: '' },
       icon: { false: '' },
@@ -81,7 +82,8 @@
       iconOnRight: { true: 'flex-row-reverse justify-end' },
       explanation: { true: 'expl-tooltip' },
       disabled: { true: 'cursor-not-allowed' },
-      rounded: { true: 'rounded-full' },
+      rounded: { true: 'rounded-[14px]' },
+      circle: { true: 'rounded-full' },
       size: {
         auto: 'p-0',
         md: 'h-8 py-[5px]',
@@ -137,8 +139,16 @@
       {
         children: false,
         icon: true,
+        rounded: false,
         size: ['md'],
         class: 'justify-center size-8 px-0',
+      },
+      {
+        children: false,
+        icon: true,
+        rounded: true,
+        size: ['md'],
+        class: 'justify-center',
       },
       {
         children: false,
@@ -184,6 +194,7 @@
       size,
       loading,
       rounded,
+      circle,
       explanation: !!explanation,
       disabled: !!rest.disabled,
       children: !!children,

--- a/src/stories/Design System - Core UI/Buttons/index.svelte
+++ b/src/stories/Design System - Core UI/Buttons/index.svelte
@@ -27,9 +27,11 @@
 
         <StatesGroup title="Default" variant="border" withIcons />
 
-        <StatesGroup title="Rounded" variant="border" withIcons rounded />
+        <StatesGroup title="Circle" variant="border" withIcons circle />
 
         <StatesGroup title="Icon" variant="border" buttons={iconButtons} />
+
+        <StatesGroup title="Icon Circle" variant="border" circle buttons={iconButtons} />
 
         <StatesGroup title="Icon Rounded" variant="border" rounded buttons={iconButtons} />
       </div>
@@ -39,9 +41,11 @@
 
         <StatesGroup title="Default" variant="ghost" withIcons />
 
-        <StatesGroup title="Rounded" variant="ghost" withIcons rounded />
+        <StatesGroup title="Circle" variant="ghost" withIcons circle />
 
         <StatesGroup title="Icon" variant="ghost" buttons={iconButtons} />
+
+        <StatesGroup title="Icon Circle" variant="ghost" circle buttons={iconButtons} />
 
         <StatesGroup title="Icon Rounded" variant="ghost" rounded buttons={iconButtons} />
       </div>


### PR DESCRIPTION
## Summary

Attempt to implement special case for icon button. This special case can be obtained with props like this `<Button variant="ghost" size="md" icon="id" rounded />` or with with defaults `<Button icon="id" rounded />"

1. Rename `rounded` prop `circle`
2. Add `rounded` prop which sets `border-radius` to `14px` and preserve default `10px` padding in icon buttons in `md` size

## Notion card
https://www.notion.so/santiment/Add-new-button-type-2562a82d1361809d9cedf82bb9315cce?source=copy_link

## Screenshots
<img width="849" height="502" alt="image" src="https://github.com/user-attachments/assets/69866e1e-2d7b-48ef-aa09-9353ea3494f1" />
