### PR TITLE
Feat/css fly scale animation

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,6 +170,7 @@
     "svelte-runes": "^0.0.7",
     "svelte-sonner": "^0.3.28",
     "tailwind-variants": "^0.3.0",
+    "tailwindcss-animate": "^1.0.7",
     "ua-parser-js": "1.0.39",
     "virtua": "0.41.5",
     "zod": "^3.23.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ dependencies:
   tailwind-variants:
     specifier: ^0.3.0
     version: 0.3.0(tailwindcss@3.4.3)
+  tailwindcss-animate:
+    specifier: ^1.0.7
+    version: 1.0.7(tailwindcss@3.4.3)
   ua-parser-js:
     specifier: 1.0.39
     version: 1.0.39
@@ -9917,6 +9920,14 @@ packages:
       tailwindcss: '*'
     dependencies:
       tailwind-merge: 2.5.4
+      tailwindcss: 3.4.3
+    dev: false
+
+  /tailwindcss-animate@1.0.7(tailwindcss@3.4.3):
+    resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders'
+    dependencies:
       tailwindcss: 3.4.3
     dev: false
 

--- a/src/lib/app.css
+++ b/src/lib/app.css
@@ -186,5 +186,19 @@ skeleton,
 }
 
 .fly-and-scale-animation {
-  @apply fill-mode-both data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[side=bottom]:slide-out-to-top-1 data-[side=left]:slide-out-to-right data-[side=top]:slide-out-to-bottom data-[side=right]:slide-out-to-left origin-[--bits-popover-content-transform-origin] !duration-200;
+  @apply data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[side=bottom]:slide-out-to-top-1 data-[side=left]:slide-out-to-right data-[side=top]:slide-out-to-bottom data-[side=right]:slide-out-to-left origin-[--bits-popover-content-transform-origin];
+}
+
+.dialog-animation {
+  @apply data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-90 data-[state=open]:zoom-in-90;
+
+  --tw-enter-translate-x: -50% !important;
+  --tw-enter-translate-y: -50% !important;
+  --tw-exit-translate-x: -50% !important;
+  --tw-exit-translate-y: -50% !important;
+}
+
+.animated {
+  @apply fill-mode-both;
+  animation-duration: 0.2s !important;
 }

--- a/src/lib/app.css
+++ b/src/lib/app.css
@@ -184,3 +184,7 @@ skeleton,
     background-position: 0 50%;
   }
 }
+
+.fly-and-scale-animation {
+  @apply fill-mode-both data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[side=bottom]:slide-out-to-top-1 data-[side=left]:slide-out-to-right data-[side=top]:slide-out-to-bottom data-[side=right]:slide-out-to-left origin-[--bits-popover-content-transform-origin] !duration-200;
+}

--- a/src/lib/app.css
+++ b/src/lib/app.css
@@ -186,7 +186,7 @@ skeleton,
 }
 
 .fly-and-scale-animation {
-  @apply data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-[side=bottom]:slide-out-to-top-1 data-[side=left]:slide-out-to-right data-[side=top]:slide-out-to-bottom data-[side=right]:slide-out-to-left origin-[--bits-popover-content-transform-origin];
+  @apply origin-[--bits-popover-content-transform-origin] data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=bottom]:slide-out-to-top-1 data-[side=left]:slide-in-from-right-2 data-[side=left]:slide-out-to-right-1 data-[side=right]:slide-in-from-left-2 data-[side=right]:slide-out-to-left-1 data-[side=top]:slide-in-from-bottom-2 data-[side=top]:slide-out-to-bottom-1;
 }
 
 .dialog-animation {

--- a/src/lib/ui/core/Dialog/Responsive/DesktopDialog.svelte
+++ b/src/lib/ui/core/Dialog/Responsive/DesktopDialog.svelte
@@ -2,9 +2,7 @@
   import type { Snippet } from 'svelte'
   import type { CreateDialogProps } from '@melt-ui/svelte'
 
-  import { fade } from 'svelte/transition'
-
-  import { cn, flyAndScale } from '$ui/utils/index.js'
+  import { cn } from '$ui/utils/index.js'
 
   import { TRANSITION_MS, useCreateDialog } from '../state.svelte.js'
 
@@ -23,6 +21,17 @@
     states: { open },
     close,
   } = useCreateDialog(onOpenChange)
+
+  function transition(el: HTMLElement) {
+    applyCloseState(el)
+    applyCloseState(el.nextElementSibling as HTMLElement)
+
+    return { duration: TRANSITION_MS + 20 }
+  }
+
+  function applyCloseState(el: HTMLElement) {
+    el.dataset.state = 'closed'
+  }
 </script>
 
 {#if $open}
@@ -30,8 +39,8 @@
     <div
       {...$overlay}
       use:overlay
-      class="fixed inset-0 z-10 bg-[#000000cf]"
-      transition:fade={{ duration: TRANSITION_MS }}
+      class="data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 animated fixed inset-0 z-10 bg-[#000000cf]"
+      out:transition
       onclick={(e) => {
         const dialogElement = e.currentTarget.nextElementSibling as null | HTMLElement
         dialogElement?.focus()
@@ -40,10 +49,9 @@
     ></div>
     <div
       class={cn(
-        'fixed left-1/2 top-1/2 z-50 max-h-[92vh] max-w-[92vw] -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded bg-white shadow-lg',
+        'animated dialog-animation fixed left-1/2 top-1/2 z-50 max-h-[92vh] max-w-[92vw] origin-center -translate-x-1/2 -translate-y-1/2 overflow-hidden rounded bg-white shadow-lg',
         className,
       )}
-      transition:flyAndScale
       {...$content}
       use:content
     >

--- a/src/lib/ui/core/Popover/Popover.svelte
+++ b/src/lib/ui/core/Popover/Popover.svelte
@@ -9,6 +9,7 @@
   } from 'bits-ui'
 
   import { cn } from '$ui/utils/index.js'
+  import { flyAndScaleOutTransition } from '$ui/utils/transitions.js'
 
   type TProps = {
     class?: string
@@ -41,11 +42,6 @@
   }: TProps = $props()
 
   const preventFocus = (e: Event) => e.preventDefault()
-
-  function transition(el: HTMLElement) {
-    el.dataset.state = 'closed'
-    return { duration: 200 }
-  }
 </script>
 
 <Popover.Root {...rootProps} bind:open={isOpened}>
@@ -72,7 +68,7 @@
           <div
             {...props}
             class={cn('fly-and-scale-animation animated', props.class as string)}
-            out:transition
+            out:flyAndScaleOutTransition
           >
             {@render content({ close: () => (isOpened = false) })}
           </div>

--- a/src/lib/ui/core/Popover/Popover.svelte
+++ b/src/lib/ui/core/Popover/Popover.svelte
@@ -73,7 +73,7 @@
           <!--<div {...props} transition:flyAndScale>-->
           <div
             {...props}
-            class={cn('fly-and-scale-animation', props.class as string)}
+            class={cn('fly-and-scale-animation animated', props.class as string)}
             out:transition
           >
             {@render content({ close: () => (isOpened = false) })}

--- a/src/lib/ui/core/Popover/Popover.svelte
+++ b/src/lib/ui/core/Popover/Popover.svelte
@@ -8,7 +8,7 @@
     type PopoverTriggerProps,
   } from 'bits-ui'
 
-  import { cn, flyAndScale } from '$ui/utils/index.js'
+  import { cn } from '$ui/utils/index.js'
 
   type TProps = {
     class?: string
@@ -43,6 +43,10 @@
   const preventFocus = (e: Event) => e.preventDefault()
 
   // TODO: Migrate js transition:flyAndScale to css from bits-ui example
+  function transition(el: HTMLElement) {
+    el.dataset.state = 'closed'
+    return { duration: 200 }
+  }
 </script>
 
 <Popover.Root {...rootProps} bind:open={isOpened}>
@@ -57,6 +61,7 @@
     {side}
     forceMount
     class={cn(
+      'bg-red',
       !noStyles && 'z-10 flex rounded border bg-white p-2 shadow-dropdown',
       matchTriggerWidth && 'w-[--bits-floating-anchor-width]',
       className,
@@ -65,7 +70,12 @@
     {#snippet child({ wrapperProps, props, open })}
       {#if open}
         <div {...wrapperProps}>
-          <div {...props} transition:flyAndScale>
+          <!--<div {...props} transition:flyAndScale>-->
+          <div
+            {...props}
+            class={cn('fly-and-scale-animation', props.class as string)}
+            out:transition
+          >
             {@render content({ close: () => (isOpened = false) })}
           </div>
         </div>

--- a/src/lib/ui/core/Popover/Popover.svelte
+++ b/src/lib/ui/core/Popover/Popover.svelte
@@ -42,7 +42,6 @@
 
   const preventFocus = (e: Event) => e.preventDefault()
 
-  // TODO: Migrate js transition:flyAndScale to css from bits-ui example
   function transition(el: HTMLElement) {
     el.dataset.state = 'closed'
     return { duration: 200 }
@@ -70,7 +69,6 @@
     {#snippet child({ wrapperProps, props, open })}
       {#if open}
         <div {...wrapperProps}>
-          <!--<div {...props} transition:flyAndScale>-->
           <div
             {...props}
             class={cn('fly-and-scale-animation animated', props.class as string)}

--- a/src/lib/ui/core/Popover/Popover.svelte
+++ b/src/lib/ui/core/Popover/Popover.svelte
@@ -56,7 +56,6 @@
     {side}
     forceMount
     class={cn(
-      'bg-red',
       !noStyles && 'z-10 flex rounded border bg-white p-2 shadow-dropdown',
       matchTriggerWidth && 'w-[--bits-floating-anchor-width]',
       className,

--- a/src/lib/ui/core/Select/Select.svelte
+++ b/src/lib/ui/core/Select/Select.svelte
@@ -72,7 +72,7 @@
         {...props}
         dropdown
         active={isOpened}
-        class={cn('[&[data-state="open"]]:bg-athens', triggerClass)}
+        class={cn('data-[state="open"]:bg-athens', triggerClass)}
         {...rest}
       >
         {#if rest.children}

--- a/src/lib/ui/core/Select/Select.svelte
+++ b/src/lib/ui/core/Select/Select.svelte
@@ -4,7 +4,7 @@
 
   import { Select } from 'bits-ui'
 
-  import { cn, flyAndScale } from '$ui/utils/index.js'
+  import { cn } from '$ui/utils/index.js'
   import Button from '$ui/core/Button/index.js'
 
   type T = $$Generic
@@ -58,6 +58,11 @@
     selected = item
     onSelect?.(item)
   }
+
+  function transition(el: HTMLElement) {
+    el.dataset.state = 'closed'
+    return { duration: 200 }
+  }
 </script>
 
 <Select.Root
@@ -98,7 +103,12 @@
     {#snippet child({ wrapperProps, props, open })}
       {#if open}
         <div {...wrapperProps}>
-          <div {...props} transition:flyAndScale bind:this={contentNode}>
+          <div
+            {...props}
+            class={cn('fly-and-scale-animation animated', props.class as string)}
+            bind:this={contentNode}
+            out:transition
+          >
             {#each items as item}
               <Select.Item
                 value={item.value as string}

--- a/src/lib/ui/core/Select/Select.svelte
+++ b/src/lib/ui/core/Select/Select.svelte
@@ -6,6 +6,7 @@
 
   import { cn } from '$ui/utils/index.js'
   import Button from '$ui/core/Button/index.js'
+  import { flyAndScaleOutTransition } from '$ui/utils/transitions.js'
 
   type T = $$Generic
   type Props = {
@@ -58,11 +59,6 @@
     selected = item
     onSelect?.(item)
   }
-
-  function transition(el: HTMLElement) {
-    el.dataset.state = 'closed'
-    return { duration: 200 }
-  }
 </script>
 
 <Select.Root
@@ -107,7 +103,7 @@
             {...props}
             class={cn('fly-and-scale-animation animated', props.class as string)}
             bind:this={contentNode}
-            out:transition
+            out:flyAndScaleOutTransition
           >
             {#each items as item}
               <Select.Item

--- a/src/lib/ui/core/Tooltip/Tooltip.svelte
+++ b/src/lib/ui/core/Tooltip/Tooltip.svelte
@@ -3,8 +3,9 @@
   import { createTooltip, type CreateTooltipProps } from '@melt-ui/svelte'
   import { ss } from 'svelte-runes'
 
-  import { cn, flyAndScale } from '$ui/utils/index.js'
+  import { cn } from '$ui/utils/index.js'
   import { useMelt } from '$ui/utils/melt-ui.js'
+  import { flyAndScaleOutTransition } from '$ui/utils/transitions.js'
 
   type FloatingConfig = NonNullable<CreateTooltipProps['positioning']>
 
@@ -70,8 +71,12 @@
   <div
     {...$content}
     use:content
-    transition:flyAndScale={{ y: -4 }}
-    class={cn(!noStyles && 'z-10 flex rounded border bg-white p-2 drop-shadow-dropdown', className)}
+    out:flyAndScaleOutTransition
+    class={cn(
+      'fly-and-scale-animation animated',
+      !noStyles && 'z-10 flex rounded border bg-white p-2 drop-shadow-dropdown',
+      className,
+    )}
   >
     {#if type === 'arrow'}
       <div {...$arrow} use:arrow></div>

--- a/src/lib/ui/utils/index.ts
+++ b/src/lib/ui/utils/index.ts
@@ -31,4 +31,4 @@ export function applyBuilder(node: HTMLElement, builder: Builder) {
   return handler
 }
 
-export { styleToString, flyAndScale } from './transitions.js'
+export { styleToString, flyAndScale, flyAndScaleOutTransition } from './transitions.js'

--- a/src/lib/ui/utils/transitions.ts
+++ b/src/lib/ui/utils/transitions.ts
@@ -49,3 +49,8 @@ export function flyAndScale(
     easing: cubicOut,
   }
 }
+
+export function flyAndScaleOutTransition(el: HTMLElement) {
+  el.dataset.state = 'closed'
+  return { duration: 200 }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 import plugin from 'tailwindcss/plugin'
+import tailwindAnimate from 'tailwindcss-animate'
 
 import { createColors } from './plugins/tailwind'
 
@@ -55,6 +56,7 @@ export default {
     },
   },
   plugins: [
+    tailwindAnimate,
     createColors({
       colors: {
         white: {


### PR DESCRIPTION
## Summary
Replaced javascript `flyAndScale` animation with native css animations for:
- `DesktopDialog`
- `Popover`
- `Tooltip`
- `Select`

New animations also support translates for the different sides (`left`,`top`, `right`, `bottom`)