### PR TITLE
fix(cursor-following): changed computePosition strategy

### DIFF
--- a/src/lib/ui/core/ExplanationTooltip/CursorFollowing.svelte
+++ b/src/lib/ui/core/ExplanationTooltip/CursorFollowing.svelte
@@ -45,6 +45,7 @@
 
     const position = await computePosition(virtualElement, tooltipElement, {
       placement: 'bottom-start',
+      strategy: 'fixed',
       middleware: [
         offsetMiddleware({ mainAxis: offset, crossAxis: offset }),
         flip(),


### PR DESCRIPTION
### Description

1. I explicitly set strategy: ‘fixed’ in computePosition.
2. I considered moving the tooltip to portal (document.body) to avoid problems with Stacking Context, but in the current implementation, this is overengineering. I left it for the future, in case there are cases with `overflow: hidden` for parents