### PR TITLE
fix(analytics): disabled automatic `send_page_view` for gtag

### DIFF
--- a/src/analytics/ga.ts
+++ b/src/analytics/ga.ts
@@ -9,5 +9,5 @@ export function initGA(id: string): void {
   newHeadScript(`window.dataLayer = window.dataLayer || [];
 function gtag(){dataLayer.push(arguments);}
 gtag('js', new Date());
-gtag('config', '${id}');`)
+gtag('config', '${id}', { send_page_view: false });`)
 }


### PR DESCRIPTION
### Description

1. Disabled `send_page_view` to prevent duplication of queries