### PR TITLE
Fix/pricing page bug fixes

### DIFF
--- a/src/lib/ui/app/Footer/links.ts
+++ b/src/lib/ui/app/Footer/links.ts
@@ -13,9 +13,9 @@ export const resourcesLinks = [
 
   { href: 'https://academy.santiment.net/', title: 'Academy' },
   { href: 'https://insights.santiment.net/', title: 'Insights' },
-  { href: SANBASE_ORIGIN + '/labs/trends', title: 'Social trends' },
+  { href: SANBASE_ORIGIN + '/social-trends/', title: 'Social trends' },
   {
-    href: SANBASE_ORIGIN + '/labs/balance',
+    href: SANBASE_ORIGIN + '/labs/balance/',
     title: 'Historical balance',
   },
   {
@@ -23,13 +23,9 @@ export const resourcesLinks = [
     title: 'Buy SAN',
   },
 
-  { href: SANBASE_ORIGIN, title: 'Sanbase' },
+  { href: SANBASE_ORIGIN + '/', title: 'Sanbase' },
   { href: 'https://api.santiment.net/', title: 'SanAPI' },
   { href: 'https://sheets.santiment.net/', title: 'Sansheets' },
-  {
-    href: 'https://graphs.santiment.net/',
-    title: 'Graphs',
-  },
 ]
 
 export const socialMediaLinks = [

--- a/src/lib/ui/app/SubscriptionPlan/BreakdownTable/Feature.svelte
+++ b/src/lib/ui/app/SubscriptionPlan/BreakdownTable/Feature.svelte
@@ -2,7 +2,7 @@
   import type { TBreakdownFeature } from './breakdown.js'
 
   import Svg from '$ui/core/Svg/index.js'
-  import Popover from '$ui/core/Popover/index.js'
+  import Tooltip from '$ui/core/Tooltip/index.js'
   import Button from '$ui/core/Button/index.js'
 
   let {
@@ -22,15 +22,15 @@
 <div class="td-h txt-left flex items-center gap-1 text-rhino">
   {name}
   {#if description}
-    <Popover side="bottom" align="center" contentProps={{ alignOffset: 8 }}>
-      {#snippet children({ props })}
-        <Button {...props} icon="info" size="sm" />
+    <Tooltip position="bottom">
+      {#snippet children({ ref })}
+        <Button {ref} icon="info" size="sm" />
       {/snippet}
 
       {#snippet content()}
         <div class="description body-3">{@html description}</div>
       {/snippet}
-    </Popover>
+    </Tooltip>
   {/if}
 </div>
 

--- a/src/lib/ui/app/SubscriptionPlan/PricingSection.svelte
+++ b/src/lib/ui/app/SubscriptionPlan/PricingSection.svelte
@@ -60,7 +60,11 @@
   </h1>
 
   <div
-    class="mb-8 inline-flex rounded-md border text-base font-medium text-waterloo sm:mb-10 sm:text-lg"
+    class={cn(
+      'mb-8 inline-flex rounded-md border text-base',
+      'font-medium text-waterloo sm:mb-10 sm:text-lg',
+      '[&:has(button:not(.outline):hover)]:bg-athens',
+    )}
   >
     {#each planTypes as item (item)}
       {@const info = PlanTypeDisplayInfo[item]}
@@ -68,7 +72,7 @@
 
       <Button
         class={cn(
-          'h-[38px] px-4 py-[8px] sm:py-3.5',
+          'h-[38px] px-4 py-[8px] hover:bg-athens sm:py-3.5',
           isActive && cn('z-10 rounded-md text-rhino outline outline-1', info.className),
         )}
         onclick={() => handlePlanClick(item)}

--- a/src/lib/ui/app/SubscriptionPlan/plans.ts
+++ b/src/lib/ui/app/SubscriptionPlan/plans.ts
@@ -135,5 +135,5 @@ export const BUSINESS_PLANS = new Set<string>([
 ])
 
 export function checkIsTrialEligiblePlan(planKey?: TSubscriptionPlan['name']) {
-  return planKey === SubscriptionPlan.PRO.key
+  return planKey === SubscriptionPlan.PRO.key || planKey === SubscriptionPlan.MAX.key
 }


### PR DESCRIPTION
### Description

  - Fixed visual gaps between rounded plan buttons on the pricing page
  - Changed feature description popover to open on hover instead of click (switched from Popover to Tooltip component)
  - Enabled "Start Free Trial" button for the Max plan (previously only shown for Pro)
  - Fixed broken footer links: added trailing slashes to prevent unwanted redirects, corrected Social Trends URL, and removed deprecated Graphs link

### Notion's task

https://www.notion.so/santiment/Pricing-page-Bug-fixes-2f42a82d136180fe9511d513913b2dbc?source=copy_link
