### PR TITLE
fix(explanation tooltip) Update color in dark mode

### DIFF
--- a/src/lib/ui/core/ExplanationTooltip/CursorFollowing.svelte
+++ b/src/lib/ui/core/ExplanationTooltip/CursorFollowing.svelte
@@ -117,7 +117,7 @@
     class={cn('pointer-events-none fixed left-0 top-0 z-10 will-change-transform')}
     style:transform="translate3d({Math.round(x)}px, {Math.round(y)}px, 0)"
   >
-    <article class={cn('rounded bg-fiord px-3 py-1.5 text-xs text-white', className)}>
+    <article class={cn('rounded bg-fiord-day px-3 py-1.5 text-xs text-white-day', className)}>
       {explanation}
     </article>
   </div>

--- a/src/lib/ui/core/ExplanationTooltip/Static.svelte
+++ b/src/lib/ui/core/ExplanationTooltip/Static.svelte
@@ -17,7 +17,7 @@
 {#if explanation}
   <Tooltip position="top" children={trigger} noStyles disableHoverableContent {...rest}>
     {#snippet content()}
-      <article class={cn('rounded bg-fiord px-3 py-1.5 text-xs text-white', contentClass)}>
+      <article class={cn('rounded bg-fiord-day px-3 py-1.5 text-xs text-white-day', contentClass)}>
         {explanation}
       </article>
     {/snippet}


### PR DESCRIPTION
## Summary

1. Update `ExplanationTooltip` colors in dark mode: make it the same as in light mode
