### PR TITLE
Feat/alert on close

### DIFF
--- a/src/lib/ui/app/Alerts/Dialog/AlertsDialog.svelte
+++ b/src/lib/ui/app/Alerts/Dialog/AlertsDialog.svelte
@@ -23,8 +23,9 @@
     source?: string
     alert?: null | Partial<TApiAlert>
     onCreate?: (alert: TApiAlert) => void
+    onClose?: () => void
   }
-  let { alert, Controller, onCreate, source = '' }: TProps = $props()
+  let { alert, Controller, onCreate, onClose, source = '' }: TProps = $props()
 
   let schema = $state.raw(deduceApiAlertSchema(alert))
 
@@ -52,6 +53,7 @@
     trackEvent('dialog', { ...analytics, action: 'open', type: '' })
 
     return () => {
+      onClose?.()
       trackEvent('dialog', { ...analytics, action: 'close', type: '' })
     }
   })

--- a/src/lib/ui/app/Alerts/Dialog/AlertsDialog.svelte
+++ b/src/lib/ui/app/Alerts/Dialog/AlertsDialog.svelte
@@ -18,6 +18,7 @@
   import { type TApiAlert } from '../types.js'
   import { deduceApiAlertSchema, type TAlertSchemaUnion } from '../categories/index.js'
   import RestrictionMessage from './RestrictionMessage.svelte'
+  import { beforeNavigate } from '$app/navigation'
 
   type TProps = TDialogProps & {
     source?: string
@@ -46,6 +47,10 @@
   }
 
   const close = () => Controller.close()
+
+  beforeNavigate(() => {
+    close()
+  })
 
   onMount(() => {
     const analytics = { source }


### PR DESCRIPTION
## Summary

1. Close `AlertsDialog` when navigating to another route
2. Add `onClose` prop callback to `AlertsDialog`

## Notion card
https://www.notion.so/santiment/Add-navigation-to-alert-3132a82d1361808abce5ed470e6a6573?source=copy_link