### PR TITLE
refactor(ui): Popover and Tooltip night-mode styling using css

### DIFF
--- a/src/lib/ui/core/Popover/Popover.svelte
+++ b/src/lib/ui/core/Popover/Popover.svelte
@@ -10,7 +10,6 @@
 
   import { cn } from '$ui/utils/index.js'
   import { flyAndScaleOutTransition } from '$ui/utils/transitions.js'
-  import { useUiCtx } from '$lib/ctx/ui/index.svelte.js'
 
   type TProps = {
     class?: string
@@ -28,8 +27,6 @@
 
     portalTo?: ComponentProps<typeof Popover.Portal>['to']
   }
-
-  const { ui } = useUiCtx()
 
   let {
     class: className,
@@ -56,7 +53,6 @@
 
   <Popover.Portal disabled={!portalTo} to={portalTo}>
     <Popover.Content
-      --active-ghost-button-bg={ui.$$.isNightMode ? 'var(--porcelain)' : undefined}
       sideOffset={8}
       onCloseAutoFocus={preventFocus}
       onOpenAutoFocus={preventFocus}
@@ -65,6 +61,7 @@
       {side}
       forceMount
       class={cn(
+        'popover-content-ui',
         !noStyles &&
           'z-10 flex rounded border bg-white p-2 shadow-dropdown dark:bg-athens dark:shadow-none',
         matchTriggerWidth && 'w-[--bits-floating-anchor-width]',
@@ -87,3 +84,9 @@
     </Popover.Content>
   </Popover.Portal>
 </Popover.Root>
+
+<style>
+  :global(.night-mode .popover-content-ui) {
+    --active-ghost-button-bg: var(--porcelain);
+  }
+</style>

--- a/src/lib/ui/core/Tooltip/Tooltip.svelte
+++ b/src/lib/ui/core/Tooltip/Tooltip.svelte
@@ -6,7 +6,6 @@
   import { cn } from '$ui/utils/index.js'
   import { useMelt } from '$ui/utils/melt-ui.js'
   import { flyAndScaleOutTransition } from '$ui/utils/transitions.js'
-  import { useUiCtx } from '$lib/ctx/ui/index.svelte.js'
 
   type FloatingConfig = NonNullable<CreateTooltipProps['positioning']>
 
@@ -35,8 +34,6 @@
     offset,
     ...options
   }: Props = $props()
-
-  const { ui } = useUiCtx()
 
   const {
     elements: { trigger, content, arrow },
@@ -75,7 +72,6 @@
     {...$content}
     use:content
     out:flyAndScaleOutTransition
-    style:--active-ghost-button-bg={ui.$$.isNightMode ? 'var(--porcelain)' : undefined}
     class={cn(
       'fly-and-scale-animation animated',
       !noStyles &&
@@ -90,3 +86,9 @@
     {@render contentSnippet({ close: () => open.set(false) })}
   </div>
 {/if}
+
+<style>
+  :global(.night-mode) div {
+    --active-ghost-button-bg: var(--porcelain);
+  }
+</style>


### PR DESCRIPTION
## Summary
Remove usage of UI context in `Popover` and `Tooltip` core components. Instead the CSS `.night-mode` selector is used to achieve correct theming.