### PR TITLE
Fix/button sizes

### DIFF
--- a/src/lib/ui/app/Alerts/Dialog/AlertFormScreen.svelte
+++ b/src/lib/ui/app/Alerts/Dialog/AlertFormScreen.svelte
@@ -61,7 +61,7 @@
           variant="plain"
           icon="arrow"
           iconSize="8"
-          class="back fill-waterloo text-waterloo hover:fill-green hover:text-green [&>svg]:-rotate-90"
+          class="back h-8 fill-waterloo text-waterloo hover:fill-green hover:text-green [&>svg]:-rotate-90"
           onclick={resetCategory}
         >
           Categories

--- a/src/lib/ui/app/Alerts/Dialog/RestrictionMessage.svelte
+++ b/src/lib/ui/app/Alerts/Dialog/RestrictionMessage.svelte
@@ -54,7 +54,6 @@
     </Button>
     <Button
       variant="plain"
-      size="auto"
       class="ml-auto fill-waterloo hover:fill-black"
       icon="close"
       iconSize="8"

--- a/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/ui/Word.svelte
+++ b/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/ui/Word.svelte
@@ -97,12 +97,7 @@
         {#if type === 'title'}
           <h4 class="mb-4 text-xs font-medium text-waterloo">{value}</h4>
         {:else}
-          <Button
-            variant="plain"
-            size="auto"
-            class="pb-3 hover:text-green"
-            onclick={() => onClick(value)}
-          >
+          <Button variant="plain" class="pb-3 hover:text-green" onclick={() => onClick(value)}>
             <Checkbox {isActive} />
             {value}
           </Button>

--- a/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/ui/index.svelte
+++ b/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/ui/index.svelte
@@ -46,7 +46,6 @@
 
       <Button
         variant="plain"
-        size="auto"
         class={cn(
           '-m-px flex-1 justify-center rounded-md border border-transparent bg-transparent px-3 py-1.5 hover:text-green',
           isActive && ' border-green bg-green-light-1 text-green',

--- a/src/lib/ui/app/Alerts/categories/wallet/wallet-form-step/ui/index.svelte
+++ b/src/lib/ui/app/Alerts/categories/wallet/wallet-form-step/ui/index.svelte
@@ -71,7 +71,6 @@
 
       <Button
         variant="plain"
-        size="auto"
         class={cn(
           'group flex flex-col items-stretch gap-1 rounded border px-4 py-3',
           disabled ? 'bg-athens text-casper' : 'hover:border-green',

--- a/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/ui/ListOfWatchlists.svelte
+++ b/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/ui/ListOfWatchlists.svelte
@@ -55,7 +55,6 @@
 
       <Button
         variant="plain"
-        size="auto"
         {disabled}
         explanation={disabled ? 'Alert for this screener already created' : undefined}
         class={cn(

--- a/src/lib/ui/app/Alerts/form-steps/metric-conditions/ui/Metric.svelte
+++ b/src/lib/ui/app/Alerts/form-steps/metric-conditions/ui/Metric.svelte
@@ -13,7 +13,6 @@
 
 <Button
   variant="plain"
-  size="auto"
   class={cn(
     'flex w-full cursor-auto flex-col items-stretch gap-1 rounded border fill-green px-4 py-2',
     onclick && 'cursor-pointer hover:border-green',

--- a/src/lib/ui/app/Alerts/form-steps/metric-conditions/ui/Metrics.svelte
+++ b/src/lib/ui/app/Alerts/form-steps/metric-conditions/ui/Metrics.svelte
@@ -48,7 +48,6 @@
 
       <Button
         variant="plain"
-        size="auto"
         class={cn(
           'rounded bg-athens px-4 py-2.5 font-semibold hover:text-green',
           isOpened && 'bg-green-light-1',

--- a/src/lib/ui/app/Chart/PaneLegend/Metric/InfoPopover.svelte
+++ b/src/lib/ui/app/Chart/PaneLegend/Metric/InfoPopover.svelte
@@ -88,9 +88,7 @@
           Academy
           <Button
             variant="link"
-            size="auto"
             target="_blank"
-            class="inline-flex"
             href="https://academy.santiment.net{openedInfo.academyLinks[0]}"
             data-source="chart_pane_legend_metric_info"
             data-type="metric_academy_article"

--- a/src/lib/ui/app/ListOfAssets/AssetItem.svelte
+++ b/src/lib/ui/app/ListOfAssets/AssetItem.svelte
@@ -23,7 +23,6 @@
 <div class="pb-1">
   <Button
     explanation={isOverflow ? `${name} (${ticker})` : undefined}
-    size="auto"
     class={cn(
       'flex w-full items-center gap-3 rounded-md px-2 py-1.5 md:px-3 md:py-2 md:text-base',
       isActive && 'text-green',

--- a/src/lib/ui/app/ListOfAssets/Tabs.svelte
+++ b/src/lib/ui/app/ListOfAssets/Tabs.svelte
@@ -40,7 +40,6 @@
   {#each tabKeys as tab}
     <Button
       variant="plain"
-      size="auto"
       class={cn(
         '-mb-[1px] border-b-2 border-b-transparent px-0.5 pb-2.5 pt-3 hover:text-green',
         selected === tab && 'border-b-green text-green',

--- a/src/lib/ui/app/Products/index.svelte
+++ b/src/lib/ui/app/Products/index.svelte
@@ -46,11 +46,11 @@
     {:else}
       <Button
         {ref}
-        size="auto"
+        variant="plain"
         icon="products-toggle"
         iconSize={16}
         class={cn(
-          'mr-10 fill-waterloo hover:bg-transparent',
+          'mr-10 fill-waterloo',
           variant === 'green' ? 'hover:fill-green' : 'hover:fill-blue',
         )}
       ></Button>

--- a/src/lib/ui/app/ProfileLink/ProfileLink.svelte
+++ b/src/lib/ui/app/ProfileLink/ProfileLink.svelte
@@ -14,7 +14,6 @@
     <div class="flex min-w-0 flex-col single-line md:gap-0.5">
       <Button
         variant="plain"
-        size="auto"
         href={SANBASE_ORIGIN + '/profile/' + currentUser.$$.id}
         class="font-medium link-as-bg md:text-base"
       >

--- a/src/lib/ui/core/Button/Button.svelte
+++ b/src/lib/ui/core/Button/Button.svelte
@@ -78,7 +78,7 @@
         border: 'border bg-transparent px-2.5 fill-waterloo hover:bg-[var(--ghost-active-bg)]',
         ghost: 'px-2.5 fill-waterloo hover:bg-[var(--ghost-active-bg)]',
         title: 'rounded-none hover:underline',
-        link: 'rounded-none text-green fill-green hover:underline',
+        link: 'rounded-none inline-flex text-green fill-green hover:underline',
         plain: 'rounded-none',
       },
       iconOnRight: { true: 'flex-row-reverse justify-end' },
@@ -134,7 +134,7 @@
         class: 'text-mystic fill-mystic hover:no-underline',
       },
       {
-        variant: 'plain',
+        variant: ['plain', 'link'],
         size: 'auto',
         class: 'p-0 h-auto text-sm',
       },

--- a/src/lib/ui/core/Button/Button.svelte
+++ b/src/lib/ui/core/Button/Button.svelte
@@ -87,7 +87,7 @@
       rounded: { true: 'rounded-[14px]' },
       circle: { true: 'rounded-full' },
       size: {
-        auto: 'h-8 py-[5px] md:h-10 md:py-1.5 md:text-base',
+        auto: 'h-8 py-[5px] sm:h-10 sm:py-1.5 sm:text-base',
         md: 'h-8 py-[5px]',
         lg: 'h-10 py-1.5 text-base',
         sm: 'p-0',
@@ -142,7 +142,7 @@
         children: false,
         icon: true,
         size: ['auto'],
-        class: 'justify-center px-0 size-8 md:size-10',
+        class: 'justify-center px-0 size-8 sm:size-10',
       },
       {
         children: false,

--- a/src/lib/ui/core/Button/Button.svelte
+++ b/src/lib/ui/core/Button/Button.svelte
@@ -6,7 +6,6 @@
 
   import { tv, type VariantProps } from 'tailwind-variants'
 
-  import { useDeviceCtx } from '$lib/ctx/device/index.svelte.js'
   import { cn } from '$ui/utils/index.js'
   import Svg, { type TSvgId } from '$ui/core/Svg/index.js'
 
@@ -42,7 +41,7 @@
     as = 'button',
     variant = 'ghost',
     accent = 'green',
-    size: initialSize,
+    size = 'auto',
     iconOnRight = false,
     rounded = false,
     circle = false,
@@ -64,11 +63,9 @@
     ...rest
   }: TProps = $props()
 
-  const { device } = useDeviceCtx()
-
-  const isPhone = $derived(device.$.isPhone)
-  const size = $derived(initialSize ?? (isPhone ? 'lg' : 'md'))
-  const iconSize = $derived(initialIconSize ?? (size === 'md' || size === 'lg' ? 16 : 12))
+  const iconSize = $derived(
+    initialIconSize ?? (size === 'auto' || size === 'md' || size === 'lg' ? 16 : 12),
+  )
 
   const button = tv({
     base: 'flex items-center cursor-pointer gap-2 rounded-md',
@@ -90,7 +87,7 @@
       rounded: { true: 'rounded-[14px]' },
       circle: { true: 'rounded-full' },
       size: {
-        auto: 'p-0',
+        auto: 'h-8 py-[5px] md:h-10 md:py-1.5 md:text-base',
         md: 'h-8 py-[5px]',
         lg: 'h-10 py-1.5 text-base',
         sm: 'p-0',
@@ -135,6 +132,17 @@
         variant: ['title', 'link'],
         disabled: true,
         class: 'text-mystic fill-mystic hover:no-underline',
+      },
+      {
+        variant: 'plain',
+        size: 'auto',
+        class: 'p-0 h-auto text-sm',
+      },
+      {
+        children: false,
+        icon: true,
+        size: ['auto'],
+        class: 'justify-center px-0 size-8 md:size-10',
       },
       {
         children: false,

--- a/src/lib/ui/core/Input/UniversalInput.svelte
+++ b/src/lib/ui/core/Input/UniversalInput.svelte
@@ -112,7 +112,6 @@
 })}
   <Button
     variant="plain"
-    size="auto"
     icon="triangle"
     iconSize="6"
     iconHeight="4"

--- a/src/lib/ui/core/Share/ShareDialog.svelte
+++ b/src/lib/ui/core/Share/ShareDialog.svelte
@@ -173,7 +173,6 @@
             href={href({ link, title: encodedTitle, text: encodedText })}
             target="_blank"
             variant="plain"
-            size="auto"
             class={cn(
               'w-full gap-3 rounded-md bg-athens fill-white px-6 py-3 capitalize',
               disabled && 'text-casper',


### PR DESCRIPTION
## Summary

Changing logic of sizes in `<Button />` to remove usage of `useDeviceCtx`.
Public API is altered

1. `auto` size prop is now default responsive prop value. It has `md` styles on Desktop and `lg` styles on Phones
2. `plain` and `link` variants now has size resetting classes (`size: auto` was used for it before). Now `plain` is true "no styling" variant
3. `link` variant is `inline-flex` by default