### PR TITLE
fix(button) Fix plain and link variants auto size reset on phone

### DIFF
--- a/src/lib/ui/core/Button/Button.svelte
+++ b/src/lib/ui/core/Button/Button.svelte
@@ -136,7 +136,7 @@
       {
         variant: ['plain', 'link'],
         size: 'auto',
-        class: 'p-0 h-auto text-sm',
+        class: 'p-0 h-auto text-sm sm:h-auto sm:text-sm sm:p-0',
       },
       {
         children: false,


### PR DESCRIPTION
## Summary
Fix `auto` size rest on phone for `plain` and `link` Button variants