### PR TITLE
Fix/cookies shadow

### DIFF
--- a/src/lib/ui/core/CookiesPopup/CookiesPopup.svelte
+++ b/src/lib/ui/core/CookiesPopup/CookiesPopup.svelte
@@ -61,7 +61,9 @@
 {#if isVisible}
   <div
     class={cn(
-      'fixed bottom-5 left-5 right-0 z-[101] max-w-[450px] rounded border bg-white pb-5 pl-[110px] pr-[43px] pt-5 shadow md:bottom-0 md:left-0 md:max-w-full md:rounded-b-none md:rounded-t-[10px] md:px-5 md:py-6 md:text-center md:text-base dark:shadow-none',
+      'fixed bottom-5 left-5 right-0 z-[101] max-w-[450px] pb-5 pl-[110px] pr-[43px] pt-5',
+      'rounded-lg border bg-white shadow-modal dark:bg-athens',
+      'md:bottom-0 md:left-0 md:max-w-full md:rounded-b-none md:rounded-t-[10px] md:px-5 md:py-6 md:text-center md:text-base',
       className,
     )}
     {style}
@@ -82,9 +84,11 @@
       <Button variant="fill" onclick={onAllowAllClick}>Allow all</Button>
       <Button
         variant="border"
+        class="bg-white"
         onclick={() => showManageCookiesDialog({}).then(() => (isVisible = false))}
-        >Manage cookies</Button
       >
+        Manage cookies
+      </Button>
     </footer>
   </div>
 {/if}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,12 +18,12 @@ export default {
 
       boxShadow: {
         dropdown: ['0 4px 16px 0 rgba(24, 27, 43, 0.13)', '0 6px 8px 0 rgba(24, 27, 43, 0.05)'],
-        modal: ['0 2px 24px 0 rgba(24, 27, 43, 0.04)', '1px 3px 7px 0 rgba(47, 53, 77, 0.05)'],
+        modal: ['0 2px 24px 3px rgba(24, 27, 43, 0.08)', '1px 3px 7px 2px rgba(47, 53, 77, 0.08)'],
       },
 
       dropShadow: {
         dropdown: ['0 4px 16px rgba(24, 27, 43, 0.13)', '0 6px 8px rgba(24, 27, 43, 0.05)'],
-        modal: ['0 2px 24px rgba(24, 27, 43, 0.04)', '1px 3px 7px rgba(47, 53, 77, 0.05)'],
+        modal: ['0 2px 24px rgba(24, 27, 43, 0.08)', '1px 3px 7px rgba(47, 53, 77, 0.08)'],
       },
 
       animation: {


### PR DESCRIPTION
## Summary


1. Update `CookiesPopup` styles:
  - bg color in dark mode
  - shadow updated. Dark mode has shadow too
  - Border radius updated
2. `shadow-modal` updated

## Notion card
https://www.notion.so/santiment/Fix-shadows-for-Cookies-popup-3202a82d136180e9895acc60db16bdae?source=copy_link

## Screenshots
<img width="573" height="251" alt="image" src="https://github.com/user-attachments/assets/cbc85514-ba0b-45a1-aba0-ebf3fefa7644" />

<img width="552" height="285" alt="image" src="https://github.com/user-attachments/assets/8cee99df-ad8b-40d0-90a5-274e3b88f9ee" />
