### PR TITLE
feat(dialog) Add more visual settings for Dialog

### DIFF
--- a/src/lib/ui/core/Dialog/Dialog.svelte
+++ b/src/lib/ui/core/Dialog/Dialog.svelte
@@ -12,11 +12,15 @@
 
   let {
     children,
-    forceMobileLandscape = false,
     class: className,
+    overlayClass,
+    forceMobileLandscape = false,
+    forceDesktop = false,
   }: {
     class?: string
+    overlayClass?: string
     forceMobileLandscape?: boolean
+    forceDesktop?: boolean
     children: Snippet<[{ close: () => void }]>
   } = $props()
 
@@ -49,11 +53,11 @@
 </script>
 
 {#if BROWSER && isOpened}
-  {#if device.$.isDesktop}
-    <DesktopDialog class={className} {children} {onOpenChange}></DesktopDialog>
+  {#if forceDesktop || device.$.isDesktop}
+    <DesktopDialog class={className} {overlayClass} {children} {onOpenChange} />
   {:else if forceMobileLandscape}
     <MobileLandscapeModal class={className} {children} {onOpenChange} />
   {:else}
-    <MobileDialog class={className} {children} {onClosed}></MobileDialog>
+    <MobileDialog class={className} {overlayClass} {children} {onClosed} />
   {/if}
 {/if}

--- a/src/lib/ui/core/Dialog/Responsive/DesktopDialog.svelte
+++ b/src/lib/ui/core/Dialog/Responsive/DesktopDialog.svelte
@@ -9,9 +9,11 @@
   let {
     children,
     class: className,
+    overlayClass,
     onOpenChange,
   }: {
     class?: string
+    overlayClass?: string
     children: Snippet<[{ close: typeof close }]>
     onOpenChange: CreateDialogProps['onOpenChange']
   } = $props()
@@ -39,7 +41,10 @@
     <div
       {...$overlay}
       use:overlay
-      class="animated fixed inset-0 z-10 bg-shark/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
+      class={cn(
+        'animated fixed inset-0 z-10 bg-shark/60 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+        overlayClass,
+      )}
       out:transition
       onclick={(e) => {
         const dialogElement = e.currentTarget.nextElementSibling as null | HTMLElement

--- a/src/lib/ui/core/Dialog/Responsive/MobileDialog.svelte
+++ b/src/lib/ui/core/Dialog/Responsive/MobileDialog.svelte
@@ -11,8 +11,10 @@
     children,
     onClosed,
     class: className,
+    overlayClass,
   }: {
     class?: string
+    overlayClass?: string
     onClosed: () => void
     children: Snippet<[{ close: typeof close }]>
   } = $props()
@@ -49,7 +51,7 @@
     <div
       {...$overlay}
       use:overlay
-      class="fixed inset-0 z-[10000] bg-shark/60 dark:bg-[#00000067]"
+      class={cn('fixed inset-0 z-[10000] bg-shark/60 dark:bg-[#00000067]', overlayClass)}
       onclick={() => Controller.close()}
     ></div>
 


### PR DESCRIPTION
## Summary

Add `overlayClass` and `forceDesktop` props to `Dialog` component

## Notion card
https://www.notion.so/santiment/Add-Voting-Banner-3252a82d136180a1808bdafd4b1dc905?source=copy_link