### PR TITLE
fix(analytics): load affiliatly script immediately if document is already complete

### DIFF
--- a/src/lib/analytics/affiliatly/index.ts
+++ b/src/lib/analytics/affiliatly/index.ts
@@ -3,9 +3,14 @@ import { newHeadScript } from '../utils.js'
 export function initAffiliatly(id: string = 'AF-1074422') {
   if (process.env.IS_LOGGING_ENABLED) return
 
-  window.addEventListener('load', () => {
+  const load = () =>
     newHeadScript(undefined, {
       src: `https://static.affiliatly.com/v3/affiliatly.js?affiliatly_code=${id}`,
     })
-  })
+
+  if (document.readyState === 'complete') {
+    load()
+  } else {
+    window.addEventListener('load', load)
+  }
 }


### PR DESCRIPTION
### Description

load affiliatly script immediately if document is already complete

### Notion's task

https://www.notion.so/santiment/Add-Affiliatly-script-3272a82d13618017bb44f4f4409dd631?source=copy_link