### PR TITLE
feat(subscription) Add support for public subscription plan data

### DIFF
--- a/src/lib/ui/app/SubscriptionPlan/index.ts
+++ b/src/lib/ui/app/SubscriptionPlan/index.ts
@@ -6,11 +6,14 @@ export {
 } from './api.js'
 
 export {
+  type TPlan,
   Product,
   SubscriptionPlan,
   SubscriptionPlanDetails,
   BUSINESS_PLANS,
   CONSUMER_PLANS,
+  getSubscriptionPlanKey,
+  convertSubscriptionPlan,
 } from './plans.js'
 export {
   checkIsSanbaseProduct,
@@ -21,6 +24,7 @@ export {
   getPlanName,
   getFormattedPlan,
 } from './utils.js'
+export { type TPublicSubscription, getPrimarySubscription } from './subscription.js'
 
 export { default as PlanButton } from './PlanButton.svelte'
 export { default as PlanCard } from './PlanCard.svelte'

--- a/src/lib/ui/app/SubscriptionPlan/plans.ts
+++ b/src/lib/ui/app/SubscriptionPlan/plans.ts
@@ -4,8 +4,8 @@ import { keyify } from '$lib/utils/object.js'
 
 export const Product = keyify(
   {
-    SanAPI: { id: '1' },
-    Sanbase: { id: '2' },
+    SanAPI: { id: '1', productName: 'SANAPI' },
+    Sanbase: { id: '2', productName: 'SANBASE' },
   },
   'name',
 )
@@ -36,6 +36,22 @@ export const SubscriptionPlan = keyify({
   BUSINESS_MAX: { name: 'Business Max' },
   CUSTOM: { name: 'Enterprise' },
 })
+
+export type TPlan = keyof typeof SubscriptionPlan
+
+export const getSubscriptionPlanKey = (planName: string): string =>
+  checkIsCustomPlan(planName) ? SubscriptionPlan.CUSTOM.key : planName
+
+export function convertSubscriptionPlan(planName: string): TPlan | null {
+  const key = getSubscriptionPlanKey(planName)
+
+  if (key in SubscriptionPlan) return key as TPlan
+
+  return null
+}
+
+export const checkIsCustomPlan = (planName: string) =>
+  planName.startsWith(SubscriptionPlan.CUSTOM.key)
 
 export const SubscriptionPlanDetails: Record<
   string,

--- a/src/lib/ui/app/SubscriptionPlan/subscription.ts
+++ b/src/lib/ui/app/SubscriptionPlan/subscription.ts
@@ -1,15 +1,13 @@
 import type { TSubscriptionPlan } from '$ui/app/SubscriptionPlan/types.js'
 
 import { calculateDaysTo } from '$lib/utils/dates/index.js'
-
-import { checkIsCustomPlan } from './utils.js'
-
-import { SubscriptionPlan } from '$ui/app/SubscriptionPlan/plans.js'
+import { checkIsCustomPlan, SubscriptionPlan } from '$ui/app/SubscriptionPlan/plans.js'
 import {
   checkIsBusinessPlan,
   checkIsSanApiProduct,
   checkIsSanbaseProduct,
   getPlanName,
+  type TLooseProduct,
 } from '$ui/app/SubscriptionPlan/utils.js'
 
 export enum Status {
@@ -33,19 +31,50 @@ export const checkIsTrialSubscription = ({ status } = {} as Pick<TSubscription, 
 export const checkIsIncompleteSubscription = ({ status } = {} as Pick<TSubscription, 'status'>) =>
   status === Status.INCOMPLETE
 
-export const checkIsActiveSubscription = (
-  { status } = {} as Pick<TSubscription, 'status'>,
-): boolean => status === Status.ACTIVE || status === Status.TRIALING || status === Status.INCOMPLETE
+const checkActiveStatus = (status: TSubscription['status']): boolean =>
+  status === Status.ACTIVE || status === Status.TRIALING || status === Status.INCOMPLETE
 
-function getSubscription(
-  subscriptions: null | TSubscription[],
-  productChecker: (product: { id: string }) => boolean,
+export type TPublicSubscription = {
+  productName: string
+  planName: string
+}
+
+type TSubscriptionLike = TSubscription | TPublicSubscription
+
+const checkIsPublicSubscription = (
+  subscription: TSubscriptionLike,
+): subscription is TPublicSubscription => 'productName' in subscription
+
+function checkIsActiveSubscription(subscription: TSubscriptionLike) {
+  if (checkIsPublicSubscription(subscription)) return true
+
+  return checkActiveStatus(subscription.status)
+}
+
+function getSubscriptionProduct(subscription: TSubscriptionLike): TLooseProduct {
+  if (checkIsPublicSubscription(subscription)) {
+    return { name: subscription.productName }
+  }
+
+  return subscription.plan.product
+}
+
+function getSubscriptionPlanName(subscription: TSubscriptionLike) {
+  if (checkIsPublicSubscription(subscription)) return subscription.planName
+
+  return subscription.plan.name
+}
+
+function getSubscription<GSub extends TSubscriptionLike>(
+  subscriptions: null | GSub[],
+  productChecker: (product: TLooseProduct) => boolean,
 ) {
   try {
     return (
       subscriptions?.find(
         (subscription) =>
-          checkIsActiveSubscription(subscription) && productChecker(subscription.plan.product),
+          checkIsActiveSubscription(subscription) &&
+          productChecker(getSubscriptionProduct(subscription)),
       ) ?? null
     )
   } catch (e) {
@@ -54,16 +83,19 @@ function getSubscription(
   }
 }
 
-export const getSanbaseSubscription = (subscriptions: null | TSubscription[]) =>
-  getSubscription(subscriptions, checkIsSanbaseProduct)
+export const getSanbaseSubscription = <GSub extends TSubscriptionLike>(
+  subscriptions: null | GSub[],
+) => getSubscription(subscriptions, checkIsSanbaseProduct)
 
-export const getApiSubscription = (subscriptions: null | TSubscription[]) =>
+export const getApiSubscription = <GSub extends TSubscriptionLike>(subscriptions: null | GSub[]) =>
   getSubscription(subscriptions, checkIsSanApiProduct)
 
-export function getPrimarySubscription(subscriptions: null | TSubscription[]) {
+export function getPrimarySubscription<GSub extends TSubscriptionLike>(
+  subscriptions: null | GSub[],
+) {
   const apiSubscription = getApiSubscription(subscriptions)
 
-  if (apiSubscription && checkIsBusinessPlan(apiSubscription.plan.name)) {
+  if (apiSubscription && checkIsBusinessPlan(getSubscriptionPlanName(apiSubscription))) {
     return apiSubscription
   }
 

--- a/src/lib/ui/app/SubscriptionPlan/utils.ts
+++ b/src/lib/ui/app/SubscriptionPlan/utils.ts
@@ -1,33 +1,35 @@
-import type { TProduct, TSubscriptionPlan } from './types.js'
+import type { TSubscriptionPlan } from './types.js'
 
 import {
   BUSINESS_PLANS,
   checkIsTrialEligiblePlan,
+  getSubscriptionPlanKey,
   Product,
   SubscriptionPlan,
   SubscriptionPlanDetails,
 } from './plans.js'
 
-export const checkIsCustomPlan = (planName: string) =>
-  planName.startsWith(SubscriptionPlan.CUSTOM.key)
+export type TLooseProduct = {
+  id?: string
+  name?: string
+}
 
-export const checkIsSanbaseProduct = (product: Pick<TProduct, 'id'>) =>
-  product.id === Product.Sanbase.id
+export const checkIsSanbaseProduct = (product: TLooseProduct) =>
+  product.id === Product.Sanbase.id || product.name === Product.Sanbase.productName
 
-export const checkIsSanApiProduct = (product: Pick<TProduct, 'id'>) =>
-  product.id === Product.SanAPI.id
+export const checkIsSanApiProduct = (product: TLooseProduct) =>
+  product.id === Product.SanAPI.id || product.name === Product.SanAPI.productName
 
 export const checkIsBusinessPlan = (planName: string | undefined) => {
   if (!planName) return false
 
-  const plan = checkIsCustomPlan(planName) ? SubscriptionPlan.CUSTOM.key : planName
-  return BUSINESS_PLANS.has(plan)
+  return BUSINESS_PLANS.has(getSubscriptionPlanKey(planName))
 }
 
 type TLooseRecord<T extends Record<string, unknown>> = T & Record<string, undefined | T[keyof T]>
 export const getPlanName = (planName: string): string => {
   const subs: TLooseRecord<typeof SubscriptionPlan> = SubscriptionPlan
-  const plan = checkIsCustomPlan(planName) ? SubscriptionPlan.CUSTOM.key : planName
+  const plan = getSubscriptionPlanKey(planName)
 
   return subs[plan]?.name || planName
 }
@@ -46,14 +48,14 @@ export function getFormattedPlan(
   monthlyPlan: TSubscriptionPlan,
   annualPlan?: null | TSubscriptionPlan,
 ) {
-  const key = monthlyPlan.name
+  const key = getSubscriptionPlanKey(monthlyPlan.name)
   const name = getPlanName(key)
   const details = SubscriptionPlanDetails[key]
 
   return {
-    isFree: monthlyPlan.name === SubscriptionPlan.FREE.key,
-    isCustom: monthlyPlan.name === SubscriptionPlan.CUSTOM.key,
-    isBusiness: BUSINESS_PLANS.has(monthlyPlan.name),
+    isFree: key === SubscriptionPlan.FREE.key,
+    isCustom: key === SubscriptionPlan.CUSTOM.key,
+    isBusiness: BUSINESS_PLANS.has(key),
 
     isTrialSupported: checkIsTrialEligiblePlan(key),
 


### PR DESCRIPTION
## Summary

Add support for public subscription data that can now be fetcher with `getUser` query

1. Export new helpers:
  - `getSubscriptionPlanKey` to adapt api key to planName (converts `CUSTOM_*` plans to `CUSTOM`)
  - `convertSubscriptionPlan` tries to convert any string plan to type safe plan (`FREE`, `PRO`, etc.). Returns `null` if failed
  - `getPrimarySubscription`. Not added, just expanded to support public subscriptions and exposed
  - `TPublicSubscription` and `TPlan` types
2. Expand current helpers to support public subscriptions
3. Do not export `checkIsActiveSubscription` since it's not used in any app and slightly simplify its api


## Notion card
https://www.notion.so/santiment/Finish-user-profile-page-with-new-data-1e02a82d13618079afbce9cdf0aac4b3?source=copy_link


