### PR TITLE
feat/charts-drawing-move

### DIFF
--- a/src/lib/ui/app/Chart/drawing-tools/_core/axis-view.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/_core/axis-view.ts
@@ -1,21 +1,21 @@
 import type { Coordinate, ISeriesPrimitiveAxisView } from '@santiment-network/chart-next'
-import type { TPoint } from '../types.js'
+
 import type { DrawingPrimitive } from './primitive.js'
 
 export abstract class DrawingAxisView implements ISeriesPrimitiveAxisView {
   protected _source: DrawingPrimitive<any>
-  protected _point: TPoint
-  protected _pos: Coordinate | null = null
+  protected _index: number
 
-  constructor(source: DrawingPrimitive<any>, point: TPoint) {
+  constructor(source: DrawingPrimitive<any>, index: number) {
     this._source = source
-    this._point = point
+    this._index = index
   }
-  abstract update(): void
+
+  abstract position: 'x' | 'y'
   abstract text(): string
 
   coordinate() {
-    return this._pos ?? -1
+    return this._source.viewPoints[this._index][this.position] ?? -1
   }
 
   visible(): boolean {
@@ -32,32 +32,24 @@ export abstract class DrawingAxisView implements ISeriesPrimitiveAxisView {
   backColor() {
     return this._source.options.axisLabels.bg
   }
-  movePoint(p: TPoint) {
-    this._point = p
-    this.update()
-  }
 }
 
 export class DrawingTimeAxisView extends DrawingAxisView {
-  update() {
-    const timeScale = this._source.chart.timeScale()
-    this._pos = timeScale.timeToCoordinate(this._point.time)
-  }
+  position = 'x' as const
+
   text() {
     const chart = this._source.chart
-    return (
-      chart.options().localization.timeFormatter?.(this._point.time) || this._point.time.toString()
-    )
+    const point = this._source.points[this._index]
+
+    return chart.options().localization.timeFormatter?.(point.time) || point.time.toString()
   }
 }
 
 export class DrawingPriceAxisView extends DrawingAxisView {
-  update() {
-    const series = this._source.series
-    this._pos = series.priceToCoordinate(this._point.price)
-  }
+  position = 'y' as const
+
   text() {
     const series = this._source.series
-    return series.priceFormatter().format(this._point.price)
+    return series.priceFormatter().format(this._source.points[this._index].price)
   }
 }

--- a/src/lib/ui/app/Chart/drawing-tools/_core/pane-view.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/_core/pane-view.ts
@@ -14,13 +14,18 @@ export abstract class DrawingPaneView implements IPrimitivePaneView {
   protected _source: DrawingPrimitive<any>
   protected _renderer!: TPaneRenderer
 
-  public points!: TViewPoint[]
+  public abstract get viewPoints(): TViewPoint[]
+
   public isHovered = false
   public isSelected = false
 
   constructor(source: DrawingPrimitive<any>) {
     this._source = source
   }
+
+  abstract update(): void
+
+  abstract renderer(): IPrimitivePaneRenderer | null
 
   public hitTest(x: Coordinate, y: Coordinate): PrimitiveHoveredItem | null {
     const result = this._renderer.hitTest(x, y)
@@ -34,7 +39,10 @@ export abstract class DrawingPaneView implements IPrimitivePaneView {
 
     return {
       // @ts-expect-error
-      externalId: this._source,
+      externalId: {
+        primitive: this._source,
+        hit: result,
+      },
       cursorStyle: 'pointer',
       zOrder: 'normal',
     }
@@ -44,27 +52,25 @@ export abstract class DrawingPaneView implements IPrimitivePaneView {
     return this.isSelected ? 'top' : 'normal'
   }
 
-  public move(diffXY: [number, number], handleId?: number) {
-    if (handleId !== undefined) {
+  public move(diffXY: [number, number], handleIndices?: [number, number]) {
+    const [diffX, diffY] = diffXY
+
+    if (handleIndices !== undefined) {
+      this.movePoint(handleIndices[0], handleIndices[1], diffX, diffY)
       return
     }
 
-    const [diffX, diffY] = diffXY
-
-    const { viewPoints, finalizedViewPoints } = this._source
-
-    for (let i = 0; i < this.points.length; i++) {
-      const viewPoint = viewPoints[i]
-      const finalizedViewPoint = finalizedViewPoints[i]
-
-      viewPoint.x = (finalizedViewPoint.x! + diffX) as Coordinate
-      viewPoint.y = (finalizedViewPoint.y! + diffY) as Coordinate
+    for (let i = 0; i < this.viewPoints.length; i++) {
+      this.movePoint(i, i, diffX, diffY)
     }
   }
 
-  abstract update(): void
+  private movePoint(xIndex: number, yIndex: number, diffX: number, diffY: number) {
+    const { viewPoints, finalizedViewPoints } = this._source
 
-  abstract renderer(): IPrimitivePaneRenderer | null
+    viewPoints[xIndex].x = (finalizedViewPoints[xIndex].x! + diffX) as Coordinate
+    viewPoints[yIndex].y = (finalizedViewPoints[yIndex].y! + diffY) as Coordinate
+  }
 }
 
 export abstract class DrawingAxisPaneView implements IPrimitivePaneView {

--- a/src/lib/ui/app/Chart/drawing-tools/_core/pane-view.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/_core/pane-view.ts
@@ -44,6 +44,24 @@ export abstract class DrawingPaneView implements IPrimitivePaneView {
     return this.isSelected ? 'top' : 'normal'
   }
 
+  public move(diffXY: [number, number], handleId?: number) {
+    if (handleId !== undefined) {
+      return
+    }
+
+    const [diffX, diffY] = diffXY
+
+    const { viewPoints, finalizedViewPoints } = this._source
+
+    for (let i = 0; i < this.points.length; i++) {
+      const viewPoint = viewPoints[i]
+      const finalizedViewPoint = finalizedViewPoints[i]
+
+      viewPoint.x = (finalizedViewPoint.x! + diffX) as Coordinate
+      viewPoint.y = (finalizedViewPoint.y! + diffY) as Coordinate
+    }
+  }
+
   abstract update(): void
 
   abstract renderer(): IPrimitivePaneRenderer | null
@@ -58,10 +76,10 @@ export abstract class DrawingAxisPaneView implements IPrimitivePaneView {
     this._source = source
   }
 
-  abstract getPoints(): (Coordinate | null)[]
-
   update() {
-    this._points = this.getPoints()
+    this._points = this._source.viewPoints.map((coordinate) =>
+      this._vertical ? coordinate.y! : coordinate.x!,
+    )
   }
 
   renderer() {
@@ -80,16 +98,6 @@ export abstract class DrawingAxisPaneView implements IPrimitivePaneView {
 
 export class DrawingPriceAxisPaneView extends DrawingAxisPaneView {
   _vertical: boolean = true
-
-  getPoints(): (Coordinate | null)[] {
-    const series = this._source.series
-    return this._source.points.map((point) => series.priceToCoordinate(point.price))
-  }
 }
 
-export class DrawingTimeAxisPaneView extends DrawingAxisPaneView {
-  getPoints(): (Coordinate | null)[] {
-    const timeScale = this._source.chart.timeScale()
-    return this._source.points.map((point) => timeScale.timeToCoordinate(point.time))
-  }
-}
+export class DrawingTimeAxisPaneView extends DrawingAxisPaneView {}

--- a/src/lib/ui/app/Chart/drawing-tools/_core/primitive.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/_core/primitive.ts
@@ -183,6 +183,8 @@ export abstract class DrawingPrimitive<GDrawingType extends string>
 
   public abstract updateEndPoint(p: TViewPoint): void
 
+  protected abstract sortViewPoints?(): void
+
   public hitTest(x: Coordinate, y: Coordinate): PrimitiveHoveredItem | null {
     const [paneView] = this._paneViews
     return paneView.hitTest(x, y)
@@ -201,8 +203,8 @@ export abstract class DrawingPrimitive<GDrawingType extends string>
     this.requestUpdate()
   }
 
-  public move(diffXY: [number, number]) {
-    this._paneViews.forEach((pw) => pw.move(diffXY))
+  public move(diffXY: [number, number], handleIndices?: [number, number]) {
+    this._paneViews.forEach((pw) => pw.move(diffXY, handleIndices))
     this.requestUpdate()
   }
 
@@ -225,6 +227,8 @@ export abstract class DrawingPrimitive<GDrawingType extends string>
     const series = this._series
 
     if (!series) return
+
+    this.sortViewPoints?.()
 
     this._dataPoints = this._viewPoints.map((point) => ({
       time: timeScale.coordinateToTime(point.x!)!,

--- a/src/lib/ui/app/Chart/drawing-tools/_core/primitive.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/_core/primitive.ts
@@ -15,7 +15,7 @@ import type {
 import { getBrowserCssVariable } from '$ui/utils/index.js'
 
 import { DrawingPriceAxisView, DrawingTimeAxisView, type DrawingAxisView } from './axis-view.js'
-import { type TOptions, type TPoint } from '../types.js'
+import { type TOptions, type TPoint, type TViewPoint } from '../types.js'
 import {
   DrawingPaneView,
   DrawingPriceAxisPaneView,
@@ -32,7 +32,9 @@ export abstract class DrawingPrimitive<GDrawingType extends string>
   protected _chart: IChartApi | undefined = undefined
   protected _series: ISeriesApi<keyof SeriesOptionsMap> | undefined = undefined
 
-  protected _points: TPoint[]
+  protected _dataPoints: TPoint[]
+  protected _viewPoints: TViewPoint[] = []
+  protected _finalizedViewPoints: TViewPoint[] = []
   protected _options: TOptions
 
   protected _timeAxisViews: DrawingAxisView[] = []
@@ -46,8 +48,9 @@ export abstract class DrawingPrimitive<GDrawingType extends string>
   }
   private _requestUpdate?: () => void
 
-  public constructor(points: TPoint[], options: Partial<TOptions> = {}) {
-    this._points = points
+  public constructor(dataPoints: TPoint[], options: Partial<TOptions> = {}) {
+    this._dataPoints = dataPoints
+
     this._options = {
       axisLabels: {
         bg: getBrowserCssVariable('casper'),
@@ -56,20 +59,36 @@ export abstract class DrawingPrimitive<GDrawingType extends string>
       ...options,
     }
 
-    for (let i = 0; i < points.length; i++) {
-      this._priceAxisViews.push(new DrawingPriceAxisView(this, points[i]))
-      this._timeAxisViews.push(new DrawingTimeAxisView(this, points[i]))
+    for (let i = 0; i < dataPoints.length; i++) {
+      this._priceAxisViews.push(new DrawingPriceAxisView(this, i))
+      this._timeAxisViews.push(new DrawingTimeAxisView(this, i))
     }
 
-    if (points.length > 1) {
+    if (dataPoints.length > 1) {
       this._priceAxisPaneViews.push(new DrawingPriceAxisPaneView(this))
       this._timeAxisPaneViews.push(new DrawingTimeAxisPaneView(this))
     }
   }
 
+  public convertDataToViewPoints() {
+    const timeScale = this._chart!.timeScale()
+    const series = this._series
+
+    if (!series) return
+
+    this._viewPoints = this._dataPoints.map((point) => ({
+      x: timeScale.timeToCoordinate(point.time),
+      y: series.priceToCoordinate(point.price),
+    }))
+    this._finalizedViewPoints = this._viewPoints.map((point) => ({ ...point }))
+  }
+
   public attached({ chart, series, requestUpdate }: SeriesAttachedParameter<Time>) {
     this._chart = chart
     this._series = series
+
+    this.convertDataToViewPoints()
+
     this._series.subscribeDataChanged(this._fireDataUpdated)
     this._requestUpdate = requestUpdate
     this.requestUpdate()
@@ -83,7 +102,7 @@ export abstract class DrawingPrimitive<GDrawingType extends string>
   }
 
   public get points(): TPoint[] {
-    return this._points
+    return this._dataPoints
   }
 
   public get chart(): IChartApi {
@@ -98,14 +117,32 @@ export abstract class DrawingPrimitive<GDrawingType extends string>
     return this._options
   }
 
+  private _oldPriceRange: undefined | Record<string, number>
+  private _oldTimeOffset: undefined | number
+  public validatePoints(): void {
+    // @ts-expect-error Getting ref to a internal cached property
+    const currentPriceRange = this._series?.priceScale()._priceScale()._priceRange
+    // @ts-expect-error Getting value of a internal cached property
+    const currentTimeOffset = this._chart?.timeScale()._timeScale._rightOffset
+
+    if (currentPriceRange === this._oldPriceRange && currentTimeOffset === this._oldTimeOffset) {
+      return
+    }
+
+    this._oldPriceRange = currentPriceRange
+    this._oldTimeOffset = currentTimeOffset
+
+    this.convertDataToViewPoints()
+  }
+
   public updateAllViews(): void {
     //if (!this._options.visible) {
     //  return
     //}
 
+    this.validatePoints()
+
     this._paneViews.forEach((pw) => pw.update())
-    this._timeAxisViews.forEach((pw) => pw.update())
-    this._priceAxisViews.forEach((pw) => pw.update())
     this._priceAxisPaneViews.forEach((pw) => pw.update())
     this._timeAxisPaneViews.forEach((pw) => pw.update())
   }
@@ -144,7 +181,7 @@ export abstract class DrawingPrimitive<GDrawingType extends string>
     }
   }
 
-  public abstract updateEndPoint(p: TPoint): void
+  public abstract updateEndPoint(p: TViewPoint): void
 
   public hitTest(x: Coordinate, y: Coordinate): PrimitiveHoveredItem | null {
     const [paneView] = this._paneViews
@@ -162,5 +199,40 @@ export abstract class DrawingPrimitive<GDrawingType extends string>
   public select(value: boolean) {
     this._paneViews[0].isSelected = value
     this.requestUpdate()
+  }
+
+  public move(diffXY: [number, number]) {
+    this._paneViews.forEach((pw) => pw.move(diffXY))
+    this.requestUpdate()
+  }
+
+  public get viewPoints(): TViewPoint[] {
+    return this._viewPoints
+  }
+
+  public get finalizedViewPoints(): TViewPoint[] {
+    return this._finalizedViewPoints
+  }
+
+  /**
+   * Convert view points to data points
+   * @returns
+   */
+  public finalize(): void {
+    if (!this._chart) return
+
+    const timeScale = this._chart.timeScale()
+    const series = this._series
+
+    if (!series) return
+
+    this._dataPoints = this._viewPoints.map((point) => ({
+      time: timeScale.coordinateToTime(point.x!)!,
+      price: series.coordinateToPrice(point.y!)!,
+    }))
+
+    this._finalizedViewPoints = this._viewPoints.map((point) => ({
+      ...point,
+    }))
   }
 }

--- a/src/lib/ui/app/Chart/drawing-tools/_core/renderer.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/_core/renderer.ts
@@ -1,10 +1,5 @@
-import type {
-  Coordinate,
-  IPrimitivePaneRenderer,
-  PrimitiveHoveredItem,
-} from '@santiment-network/chart-next'
+import type { Coordinate, IPrimitivePaneRenderer } from '@santiment-network/chart-next'
 import type { CanvasRenderingTarget2D } from 'fancy-canvas'
-import type { TViewPoint } from '../types.js'
 
 import { getBrowserCssVariable } from '$ui/utils/index.js'
 import type { DrawingPaneView } from './pane-view.js'
@@ -16,8 +11,17 @@ export const RenderHitTest = {
 
 export type TRenderHitTestValue = (typeof RenderHitTest)[keyof typeof RenderHitTest]
 
+export type TRenderHitTestData =
+  | {
+      type: (typeof RenderHitTest)['PRIMITIVE']
+    }
+  | {
+      type: (typeof RenderHitTest)['HANDLE']
+      indices: [number, number]
+    }
+
 export interface TPaneRenderer extends IPrimitivePaneRenderer {
-  hitTest(x: Coordinate, y: Coordinate): TRenderHitTestValue | null
+  hitTest(x: Coordinate, y: Coordinate): TRenderHitTestData | null
 }
 
 export class DrawingCompositePaneRenderer implements TPaneRenderer {
@@ -33,9 +37,9 @@ export class DrawingCompositePaneRenderer implements TPaneRenderer {
     }
   }
 
-  hitTest(x: Coordinate, y: Coordinate): TRenderHitTestValue | null {
-    for (const renderer of this._renderers) {
-      const result = renderer.hitTest?.(x, y)
+  hitTest(x: Coordinate, y: Coordinate): TRenderHitTestData | null {
+    for (let i = this._renderers.length - 1; i > -1; i--) {
+      const result = this._renderers[i].hitTest?.(x, y)
 
       if (result !== null) {
         return result
@@ -48,17 +52,19 @@ export class DrawingCompositePaneRenderer implements TPaneRenderer {
 
 export class HandleRenderer<GPaneView extends DrawingPaneView> {
   protected _paneView: GPaneView
-  protected _points: GPaneView['points']
 
-  private _config: { position: (points: GPaneView['points']) => any }
+  private _config: {
+    pointIndices: [number, number]
+  }
   private _size = 8 / 2
 
   constructor(
     paneView: GPaneView,
-    config: { position: (points: GPaneView['points']) => TViewPoint },
+    config: {
+      pointIndices: [number, number]
+    },
   ) {
     this._paneView = paneView
-    this._points = paneView.points
     this._config = config
   }
 
@@ -68,7 +74,12 @@ export class HandleRenderer<GPaneView extends DrawingPaneView> {
     }
 
     target.useBitmapCoordinateSpace((scope) => {
-      const { x, y } = this._config.position(this._points)
+      const x = this._paneView.viewPoints[this._config.pointIndices[0]].x
+      const y = this._paneView.viewPoints[this._config.pointIndices[1]].y
+
+      if (x === null || y === null) {
+        return
+      }
 
       const ctx = scope.context
       const horizontalPositions = positionsBox(
@@ -101,23 +112,17 @@ export class HandleRenderer<GPaneView extends DrawingPaneView> {
     })
   }
 
-  hitTest(x: Coordinate, y: Coordinate): TRenderHitTestValue | null {
-    const point = this._config.position(this._points)
+  hitTest(x: Coordinate, y: Coordinate): TRenderHitTestData | null {
+    const px = this._paneView.viewPoints[this._config.pointIndices[0]].x!
+    const py = this._paneView.viewPoints[this._config.pointIndices[1]].y!
 
     if (
-      checkIsOutsideRect(
-        x,
-        y,
-        point.x - this._size,
-        point.x + this._size,
-        point.y - this._size,
-        point.y + this._size,
-      )
+      checkIsOutsideRect(x, y, px - this._size, px + this._size, py - this._size, py + this._size)
     ) {
       return null
     }
 
-    return RenderHitTest.HANDLE
+    return { type: RenderHitTest.HANDLE, indices: this._config.pointIndices }
   }
 }
 

--- a/src/lib/ui/app/Chart/drawing-tools/ctx.svelte.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/ctx.svelte.ts
@@ -30,6 +30,13 @@ type TStates =
         Primitive: undefined | Promise<{ default: TDrawingPrimitives }>
       }
     >
+  | TState<
+      'moving',
+      {
+        drawing: TDrawingPrimitive
+        startPoint: NonNullable<MouseEventParams['point']>
+      }
+    >
 
 export function importPrimitive(type: TDrawingTypes) {
   switch (type) {
@@ -107,13 +114,30 @@ export const useDrawingToolsCtx = createCtx(
         const { handleScroll } = chart.options()
         const oldHandleScroll =
           typeof handleScroll === 'object' ? { ...handleScroll } : handleScroll
-        chart.applyOptions({ handleScroll: { pressedMouseMove: false } })
+        chart.applyOptions({ handleScroll: false })
 
         window.addEventListener(
           'pointerup',
-          () => chart.applyOptions({ handleScroll: oldHandleScroll }),
+          () => {
+            if (state.name !== 'drawing') {
+              state.payload?.drawing?.finalize()
+              state = { name: 'idle', payload: null }
+            }
+
+            chart.applyOptions({ handleScroll: oldHandleScroll })
+          },
           { once: true },
         )
+      }
+
+      if (hoveredPrimitive && state.name === 'idle') {
+        state = {
+          name: 'moving',
+          payload: {
+            drawing: hoveredPrimitive,
+            startPoint: params.point!,
+          },
+        }
       }
 
       if (state.name !== 'drawing') return
@@ -137,7 +161,8 @@ export const useDrawingToolsCtx = createCtx(
           state.payload.drawing = primitive
           state.payload.points = points
         } else {
-          state.payload.drawing.updateEndPoint(point)
+          state.payload.drawing.updateEndPoint(params.point!)
+          state.payload.drawing.finalize()
 
           state = { name: 'idle', payload: null }
         }
@@ -145,14 +170,26 @@ export const useDrawingToolsCtx = createCtx(
     }
 
     function onChartCrosshairMove(params: MouseEventParams) {
+      if (state.name === 'moving') {
+        const { startPoint } = state.payload
+        if (!params.point) return
+
+        const { x, y } = params.point
+        const dx = x - startPoint.x
+        const dy = y - startPoint.y
+
+        // console.log({ dx, dy })
+        state.payload.drawing.move([dx, dy])
+      }
+
       if (state.name !== 'drawing') return
 
-      const point = getMouseDrawingPoint(params)
-      if (!point) return
+      // const point = getMouseDrawingPoint(params)
+      // if (!point) return
 
       if (!state.payload.drawing) return
 
-      state.payload.drawing.updateEndPoint(point)
+      state.payload.drawing.updateEndPoint(params.point!)
     }
 
     $effect(() => {
@@ -162,7 +199,7 @@ export const useDrawingToolsCtx = createCtx(
       chart.subscribePointerDown(onChartPointerDown)
 
       $effect(() => {
-        if (state.name !== 'drawing') return
+        if (state.name !== 'drawing' && state.name !== 'moving') return
 
         chart.subscribeCrosshairMove(onChartCrosshairMove)
         return () => {

--- a/src/lib/ui/app/Chart/drawing-tools/ctx.svelte.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/ctx.svelte.ts
@@ -6,6 +6,7 @@ import type { default as RectanglePrimitive } from './rectangle/primitive.js'
 import { createCtx } from '$lib/utils/index.js'
 
 import { useChartCtx, useMetricSeriesCtx } from '../ctx/index.js'
+import { RenderHitTest, type TRenderHitTestData } from './_core/renderer.js'
 
 type TDrawingPrimitives = typeof RectanglePrimitive | typeof FibRetracementPrimitive
 type TDrawingPrimitive = TDrawingPrimitives['prototype']
@@ -35,8 +36,14 @@ type TStates =
       {
         drawing: TDrawingPrimitive
         startPoint: NonNullable<MouseEventParams['point']>
+        handleIndices?: [number, number]
       }
     >
+
+type THoveredPrimitive = {
+  primitive: TDrawingPrimitive
+  hit: TRenderHitTestData
+}
 
 export function importPrimitive(type: TDrawingTypes) {
   switch (type) {
@@ -105,7 +112,8 @@ export const useDrawingToolsCtx = createCtx(
         return
       }
 
-      const hoveredPrimitive = params.hoveredObjectId as null | TDrawingPrimitive
+      const hoveredObject = params.hoveredObjectId as null | THoveredPrimitive
+      const hoveredPrimitive = hoveredObject?.primitive ?? null
 
       selectPrimitive(hoveredPrimitive)
 
@@ -136,6 +144,10 @@ export const useDrawingToolsCtx = createCtx(
           payload: {
             drawing: hoveredPrimitive,
             startPoint: params.point!,
+            handleIndices:
+              hoveredObject?.hit.type === RenderHitTest.HANDLE
+                ? hoveredObject.hit.indices
+                : undefined,
           },
         }
       }
@@ -179,7 +191,7 @@ export const useDrawingToolsCtx = createCtx(
         const dy = y - startPoint.y
 
         // console.log({ dx, dy })
-        state.payload.drawing.move([dx, dy])
+        state.payload.drawing.move([dx, dy], state.payload.handleIndices)
       }
 
       if (state.name !== 'drawing') return
@@ -188,8 +200,9 @@ export const useDrawingToolsCtx = createCtx(
       // if (!point) return
 
       if (!state.payload.drawing) return
+      if (!params.point) return
 
-      state.payload.drawing.updateEndPoint(params.point!)
+      state.payload.drawing.updateEndPoint(params.point)
     }
 
     $effect(() => {

--- a/src/lib/ui/app/Chart/drawing-tools/ctx.svelte.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/ctx.svelte.ts
@@ -92,10 +92,29 @@ export const useDrawingToolsCtx = createCtx(
       return { time: params.time, price: value }
     }
 
-    function onChartClick(params: MouseEventParams) {
+    function onChartPointerDown(params: MouseEventParams) {
+      const chart = chartCtx.chart.$
+      if (!chart) {
+        return
+      }
+
       const hoveredPrimitive = params.hoveredObjectId as null | TDrawingPrimitive
 
       selectPrimitive(hoveredPrimitive)
+
+      // NOTE: Preventing mouse drag-scroll when drawing or hovering over a primitive and then pressing the mouse button
+      if (hoveredPrimitive || state.name === 'drawing') {
+        const { handleScroll } = chart.options()
+        const oldHandleScroll =
+          typeof handleScroll === 'object' ? { ...handleScroll } : handleScroll
+        chart.applyOptions({ handleScroll: { pressedMouseMove: false } })
+
+        window.addEventListener(
+          'pointerup',
+          () => chart.applyOptions({ handleScroll: oldHandleScroll }),
+          { once: true },
+        )
+      }
 
       if (state.name !== 'drawing') return
 
@@ -140,7 +159,7 @@ export const useDrawingToolsCtx = createCtx(
       const chart = chartCtx.chart.$
       if (!chart) return
 
-      chart.subscribeClick(onChartClick)
+      chart.subscribePointerDown(onChartPointerDown)
 
       $effect(() => {
         if (state.name !== 'drawing') return
@@ -152,7 +171,7 @@ export const useDrawingToolsCtx = createCtx(
       })
 
       return () => {
-        chart.unsubscribeClick(onChartClick)
+        chart.unsubscribePointerDown(onChartPointerDown)
       }
     })
 

--- a/src/lib/ui/app/Chart/drawing-tools/fib-retracement/primitive.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/fib-retracement/primitive.ts
@@ -1,4 +1,4 @@
-import type { TPoint } from '../types.js'
+import type { TPoint, TViewPoint } from '../types.js'
 
 import { DrawingPrimitive } from '../_core/primitive.js'
 import { FibRetracementPaneView } from './pane-view.js'
@@ -8,12 +8,12 @@ export default class FibRetracementPrimitive extends DrawingPrimitive<'fib_retra
 
   protected _paneViews: FibRetracementPaneView[] = [new FibRetracementPaneView(this)]
 
-  public updateEndPoint(point: TPoint) {
-    this._points[1] = point
+  public updateEndPoint(point: TViewPoint) {
+    this._dataPoints[1] = point
 
     this._paneViews[0].update()
-    this._timeAxisViews[1].movePoint(point)
-    this._priceAxisViews[1].movePoint(point)
+    // this._timeAxisViews[1].movePoint(point)
+    // this._priceAxisViews[1].movePoint(point)
 
     this.requestUpdate()
   }

--- a/src/lib/ui/app/Chart/drawing-tools/rectangle/pane-view.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/rectangle/pane-view.ts
@@ -45,22 +45,25 @@ export class RectanglePaneView extends DrawingPaneView {
   ])
 
   update() {
+    // console.log('auto update?')
     const series = this._source.series
     const timeScale = this._source.chart.timeScale()
 
-    const [p1, p2] = this._source.points
+    // const [p1, p2] = this._source.points
 
-    const y1 = series.priceToCoordinate(p1.price)
-    const y2 = series.priceToCoordinate(p2.price)
+    // const y1 = series.priceToCoordinate(p1.price)
+    // const y2 = series.priceToCoordinate(p2.price)
 
-    const x1 = timeScale.timeToCoordinate(p1.time)
-    const x2 = timeScale.timeToCoordinate(p2.time)
+    // const x1 = timeScale.timeToCoordinate(p1.time)
+    // const x2 = timeScale.timeToCoordinate(p2.time)
 
-    const [top, bottom] = y1! < y2! ? [y1, y2] : [y2, y1]
-    const [left, right] = x1! < x2! ? [x1, x2] : [x2, x1]
+    // const [top, bottom] = y1! < y2! ? [y1, y2] : [y2, y1]
+    // const [left, right] = x1! < x2! ? [x1, x2] : [x2, x1]
 
-    this.points[0] = { x: left, y: top }
-    this.points[1] = { x: right, y: bottom }
+    // this.points[0] = { x: left, y: top }
+    // this.points[1] = { x: right, y: bottom }
+    this.points[0] = this._source.viewPoints[0]
+    this.points[1] = this._source.viewPoints[1]
   }
 
   renderer() {

--- a/src/lib/ui/app/Chart/drawing-tools/rectangle/pane-view.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/rectangle/pane-view.ts
@@ -7,64 +7,35 @@ import { DrawingCompositePaneRenderer, HandleRenderer } from '../_core/renderer.
 import { RectanglePaneRenderer } from './renderer.js'
 
 export class RectanglePaneView extends DrawingPaneView {
-  public points: [TViewPoint, TViewPoint] = [
-    { x: null, y: null },
-    { x: null, y: null },
-  ]
+  public get viewPoints(): [TViewPoint, TViewPoint] {
+    return this._source.viewPoints as [TViewPoint, TViewPoint]
+  }
 
   protected _renderer: DrawingCompositePaneRenderer = new DrawingCompositePaneRenderer([
-    new RectanglePaneRenderer(this.points, getBrowserCssVariable('red') + '50'),
+    new RectanglePaneRenderer(this, getBrowserCssVariable('red') + '50'),
 
     // top left
     new HandleRenderer(this, {
-      position(points) {
-        return { x: points[0].x, y: points[0].y }
-      },
+      pointIndices: [0, 0],
     }),
 
     // top right
     new HandleRenderer(this, {
-      position(points) {
-        return { x: points[1].x, y: points[0].y }
-      },
+      pointIndices: [1, 0],
     }),
 
     // bottom right
     new HandleRenderer(this, {
-      position(points) {
-        return { x: points[1].x, y: points[1].y }
-      },
+      pointIndices: [1, 1],
     }),
 
     // bottom left
     new HandleRenderer(this, {
-      position(points) {
-        return { x: points[0].x, y: points[1].y }
-      },
+      pointIndices: [0, 1],
     }),
   ])
 
-  update() {
-    // console.log('auto update?')
-    const series = this._source.series
-    const timeScale = this._source.chart.timeScale()
-
-    // const [p1, p2] = this._source.points
-
-    // const y1 = series.priceToCoordinate(p1.price)
-    // const y2 = series.priceToCoordinate(p2.price)
-
-    // const x1 = timeScale.timeToCoordinate(p1.time)
-    // const x2 = timeScale.timeToCoordinate(p2.time)
-
-    // const [top, bottom] = y1! < y2! ? [y1, y2] : [y2, y1]
-    // const [left, right] = x1! < x2! ? [x1, x2] : [x2, x1]
-
-    // this.points[0] = { x: left, y: top }
-    // this.points[1] = { x: right, y: bottom }
-    this.points[0] = this._source.viewPoints[0]
-    this.points[1] = this._source.viewPoints[1]
-  }
+  update() {}
 
   renderer() {
     return this._renderer

--- a/src/lib/ui/app/Chart/drawing-tools/rectangle/primitive.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/rectangle/primitive.ts
@@ -1,19 +1,26 @@
-import type { TPoint, TViewPoint } from '../types.js'
+import type { TViewPoint } from '../types.js'
 
 import { DrawingPrimitive } from '../_core/primitive.js'
 import { RectanglePaneView } from './pane-view.js'
 
 export default class RectanglePrimitive extends DrawingPrimitive<'rectangle'> {
   public __type = 'rectangle' as const
+
   protected _paneViews: RectanglePaneView[] = [new RectanglePaneView(this)]
 
   public updateEndPoint(point: TViewPoint) {
     this.viewPoints[this.viewPoints.length - 1] = point
 
-    this._paneViews[0].update()
-    // this._timeAxisViews[1].movePoint()
-    // this._priceAxisViews[1].movePoint()
-
     this.requestUpdate()
+  }
+
+  protected sortViewPoints(): void {
+    const [p1, p2] = this.viewPoints
+
+    const [top, bottom] = p1.y! < p2.y! ? [p1.y, p2.y] : [p2.y, p1.y]
+    const [left, right] = p1.x! < p2.x! ? [p1.x, p2.x] : [p2.x, p1.x]
+
+    Object.assign(p1, { x: left, y: top })
+    Object.assign(p2, { x: right, y: bottom })
   }
 }

--- a/src/lib/ui/app/Chart/drawing-tools/rectangle/primitive.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/rectangle/primitive.ts
@@ -1,4 +1,4 @@
-import type { TPoint } from '../types.js'
+import type { TPoint, TViewPoint } from '../types.js'
 
 import { DrawingPrimitive } from '../_core/primitive.js'
 import { RectanglePaneView } from './pane-view.js'
@@ -7,13 +7,12 @@ export default class RectanglePrimitive extends DrawingPrimitive<'rectangle'> {
   public __type = 'rectangle' as const
   protected _paneViews: RectanglePaneView[] = [new RectanglePaneView(this)]
 
-  public updateEndPoint(point: TPoint) {
-    this._points[1] = point
-    //this._p2 = point
+  public updateEndPoint(point: TViewPoint) {
+    this.viewPoints[this.viewPoints.length - 1] = point
 
     this._paneViews[0].update()
-    this._timeAxisViews[1].movePoint(point)
-    this._priceAxisViews[1].movePoint(point)
+    // this._timeAxisViews[1].movePoint()
+    // this._priceAxisViews[1].movePoint()
 
     this.requestUpdate()
   }

--- a/src/lib/ui/app/Chart/drawing-tools/rectangle/renderer.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/rectangle/renderer.ts
@@ -1,5 +1,4 @@
 import type { CanvasRenderingTarget2D } from 'fancy-canvas'
-import type { TViewPoint } from '../types.js'
 import type { Coordinate, PrimitiveHoveredItem } from '@santiment-network/chart-next'
 
 import {
@@ -7,21 +6,22 @@ import {
   positionsBox,
   RenderHitTest,
   type TPaneRenderer,
-  type TRenderHitTestValue,
+  type TRenderHitTestData,
 } from '../_core/renderer.js'
+import type { RectanglePaneView } from './pane-view.js'
 
 export class RectanglePaneRenderer implements TPaneRenderer {
-  private _data: [TViewPoint, TViewPoint]
+  private _paneView: RectanglePaneView
   private _fillColor: string
 
-  constructor(data: [TViewPoint, TViewPoint], fillColor: string) {
-    this._data = data
+  constructor(paneView: RectanglePaneView, fillColor: string) {
+    this._paneView = paneView
     this._fillColor = fillColor
   }
 
   draw(target: CanvasRenderingTarget2D) {
     target.useBitmapCoordinateSpace((scope) => {
-      const [p1, p2] = this._data
+      const [p1, p2] = this._paneView.viewPoints
 
       if (p1.x === null || p1.y === null || p2.x === null || p2.y === null) {
         return
@@ -40,13 +40,13 @@ export class RectanglePaneRenderer implements TPaneRenderer {
     })
   }
 
-  hitTest(x: Coordinate, y: Coordinate): TRenderHitTestValue | null {
-    const [p1, p2] = this._data
+  hitTest(x: Coordinate, y: Coordinate): TRenderHitTestData | null {
+    const [p1, p2] = this._paneView.viewPoints
 
     if (checkIsOutsideRect(x, y, p1.x, p2.x, p1.y, p2.y)) {
       return null
     }
 
-    return RenderHitTest.PRIMITIVE
+    return { type: RenderHitTest.PRIMITIVE }
   }
 }


### PR DESCRIPTION
# Summary
Making drawings interactive by implementing drawing tool's `hitTest` method and passing hovered object data on chart pointerDown event.
Moving handle modifies the exact point it is attached to. Moving whole drawing modifies all points.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #409
- <kbd>&nbsp;4&nbsp;</kbd> #408
- <kbd>&nbsp;3&nbsp;</kbd> #407 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #406
- <kbd>&nbsp;1&nbsp;</kbd> #405
<!-- GitButler Footer Boundary Bottom -->