### PR TITLE
feat/charts-drawing-lines

### DIFF
--- a/src/lib/ui/app/Chart/drawing-tools/_core/axis-view.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/_core/axis-view.ts
@@ -1,5 +1,4 @@
-import type { Coordinate, ISeriesPrimitiveAxisView } from '@santiment-network/chart-next'
-
+import type { ISeriesPrimitiveAxisView } from '@santiment-network/chart-next'
 import type { DrawingPrimitive } from './primitive.js'
 
 export abstract class DrawingAxisView implements ISeriesPrimitiveAxisView {

--- a/src/lib/ui/app/Chart/drawing-tools/_core/pane-view.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/_core/pane-view.ts
@@ -65,7 +65,7 @@ export abstract class DrawingPaneView implements IPrimitivePaneView {
     }
   }
 
-  private movePoint(xIndex: number, yIndex: number, diffX: number, diffY: number) {
+  protected movePoint(xIndex: number, yIndex: number, diffX: number, diffY: number) {
     const { viewPoints, finalizedViewPoints } = this._source
 
     viewPoints[xIndex].x = (finalizedViewPoints[xIndex].x! + diffX) as Coordinate

--- a/src/lib/ui/app/Chart/drawing-tools/_core/pane-view.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/_core/pane-view.ts
@@ -6,9 +6,9 @@ import type {
   PrimitivePaneViewZOrder,
 } from '@santiment-network/chart-next'
 import type { DrawingPrimitive } from './primitive.js'
+import type { TViewPoint } from '../types.js'
 
 import { DrawingAxisPaneRenderer, type TPaneRenderer } from './renderer.js'
-import type { TViewPoint } from '../types.js'
 
 export abstract class DrawingPaneView implements IPrimitivePaneView {
   protected _source: DrawingPrimitive<any>

--- a/src/lib/ui/app/Chart/drawing-tools/_core/primitive.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/_core/primitive.ts
@@ -70,16 +70,23 @@ export abstract class DrawingPrimitive<GDrawingType extends string>
     }
   }
 
-  public convertDataToViewPoints() {
+  protected mapDataPointsToViewPoints(): undefined | TViewPoint[] {
     const timeScale = this._chart!.timeScale()
     const series = this._series
 
     if (!series) return
 
-    this._viewPoints = this._dataPoints.map((point) => ({
+    return this._dataPoints.map((point) => ({
       x: timeScale.timeToCoordinate(point.time),
       y: series.priceToCoordinate(point.price),
     }))
+  }
+
+  public convertDataToViewPoints() {
+    const viewPoints = this.mapDataPointsToViewPoints()
+    if (!viewPoints) return
+
+    this._viewPoints = viewPoints
     this._finalizedViewPoints = this._viewPoints.map((point) => ({ ...point }))
   }
 
@@ -216,6 +223,18 @@ export abstract class DrawingPrimitive<GDrawingType extends string>
     return this._finalizedViewPoints
   }
 
+  protected mapViewPointsToDataPoints(): undefined | TPoint[] {
+    const timeScale = this._chart!.timeScale()
+    const series = this._series
+
+    if (!series) return
+
+    return this._viewPoints.map((point) => ({
+      time: timeScale.coordinateToTime(point.x!)!,
+      price: series.coordinateToPrice(point.y!)!,
+    }))
+  }
+
   /**
    * Convert view points to data points
    * @returns
@@ -223,20 +242,12 @@ export abstract class DrawingPrimitive<GDrawingType extends string>
   public finalize(): void {
     if (!this._chart) return
 
-    const timeScale = this._chart.timeScale()
-    const series = this._series
-
-    if (!series) return
-
     this.sortViewPoints?.()
 
-    this._dataPoints = this._viewPoints.map((point) => ({
-      time: timeScale.coordinateToTime(point.x!)!,
-      price: series.coordinateToPrice(point.y!)!,
-    }))
+    const dataPoints = this.mapViewPointsToDataPoints()
+    if (!dataPoints) return
 
-    this._finalizedViewPoints = this._viewPoints.map((point) => ({
-      ...point,
-    }))
+    this._dataPoints = dataPoints
+    this._finalizedViewPoints = this._viewPoints.map((point) => ({ ...point }))
   }
 }

--- a/src/lib/ui/app/Chart/drawing-tools/_core/renderer.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/_core/renderer.ts
@@ -3,6 +3,7 @@ import type { CanvasRenderingTarget2D } from 'fancy-canvas'
 import type { DrawingPaneView } from './pane-view.js'
 
 import { getBrowserCssVariable } from '$ui/utils/index.js'
+import type { TViewPoint } from '../types.js'
 
 export const RenderHitTest = {
   PRIMITIVE: 1,
@@ -50,22 +51,26 @@ export class DrawingCompositePaneRenderer implements TPaneRenderer {
   }
 }
 
+type THandleConfig = {
+  pointIndices: [number, number]
+}
+
 export class HandleRenderer<GPaneView extends DrawingPaneView> {
   protected _paneView: GPaneView
 
-  private _config: {
-    pointIndices: [number, number]
-  }
+  private _config: THandleConfig
   private _size = 8 / 2
 
-  constructor(
-    paneView: GPaneView,
-    config: {
-      pointIndices: [number, number]
-    },
-  ) {
+  constructor(paneView: GPaneView, config: THandleConfig) {
     this._paneView = paneView
     this._config = config
+  }
+
+  get viewPoint(): TViewPoint {
+    const x = this._paneView.viewPoints[this._config.pointIndices[0]].x
+    const y = this._paneView.viewPoints[this._config.pointIndices[1]].y
+
+    return { x, y }
   }
 
   draw(target: CanvasRenderingTarget2D) {
@@ -74,8 +79,7 @@ export class HandleRenderer<GPaneView extends DrawingPaneView> {
     }
 
     target.useBitmapCoordinateSpace((scope) => {
-      const x = this._paneView.viewPoints[this._config.pointIndices[0]].x
-      const y = this._paneView.viewPoints[this._config.pointIndices[1]].y
+      const { x, y } = this.viewPoint
 
       if (x === null || y === null) {
         return
@@ -113,11 +117,17 @@ export class HandleRenderer<GPaneView extends DrawingPaneView> {
   }
 
   hitTest(x: Coordinate, y: Coordinate): TRenderHitTestData | null {
-    const px = this._paneView.viewPoints[this._config.pointIndices[0]].x!
-    const py = this._paneView.viewPoints[this._config.pointIndices[1]].y!
+    const { x: px, y: py } = this.viewPoint
 
     if (
-      checkIsOutsideRect(x, y, px - this._size, px + this._size, py - this._size, py + this._size)
+      checkIsOutsideRect(
+        x,
+        y,
+        px! - this._size,
+        px! + this._size,
+        py! - this._size,
+        py! + this._size,
+      )
     ) {
       return null
     }
@@ -212,7 +222,7 @@ export function checkIsOutsideRect(
   return x < px1! || x > px2! || y < py1! || y > py2!
 }
 
-const TOLERANCE = 6
+const TOLERANCE = 7
 
 /**
  *

--- a/src/lib/ui/app/Chart/drawing-tools/_core/renderer.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/_core/renderer.ts
@@ -1,9 +1,9 @@
 import type { Coordinate, IPrimitivePaneRenderer } from '@santiment-network/chart-next'
 import type { CanvasRenderingTarget2D } from 'fancy-canvas'
 import type { DrawingPaneView } from './pane-view.js'
+import type { TViewPoint } from '../types.js'
 
 import { getBrowserCssVariable } from '$ui/utils/index.js'
-import type { TViewPoint } from '../types.js'
 
 export const RenderHitTest = {
   PRIMITIVE: 1,

--- a/src/lib/ui/app/Chart/drawing-tools/_core/renderer.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/_core/renderer.ts
@@ -1,8 +1,8 @@
 import type { Coordinate, IPrimitivePaneRenderer } from '@santiment-network/chart-next'
 import type { CanvasRenderingTarget2D } from 'fancy-canvas'
+import type { DrawingPaneView } from './pane-view.js'
 
 import { getBrowserCssVariable } from '$ui/utils/index.js'
-import type { DrawingPaneView } from './pane-view.js'
 
 export const RenderHitTest = {
   PRIMITIVE: 1,
@@ -178,6 +178,10 @@ export function positionsBox(
     position: Math.min(scaledPosition1, scaledPosition2),
     length: Math.abs(scaledPosition2 - scaledPosition1) + 1,
   }
+}
+
+export function positionPoint(coor: number, pixelRatio: number) {
+  return Math.round(coor * pixelRatio)
 }
 
 export interface BitmapPositionLength {

--- a/src/lib/ui/app/Chart/drawing-tools/ctx.svelte.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/ctx.svelte.ts
@@ -3,6 +3,7 @@ import type { TPoint } from './types.js'
 import type { default as FibRetracementPrimitive } from './fib-retracement/primitive.js'
 import type { default as RectanglePrimitive } from './rectangle/primitive.js'
 import type { default as TrendlinePrimitive } from './trendline/primitive.js'
+import type { default as HorizontalLinePrimitive } from './horizontal-line/primitive.js'
 
 import { createCtx } from '$lib/utils/index.js'
 
@@ -13,6 +14,7 @@ type TDrawingPrimitives =
   | typeof RectanglePrimitive
   | typeof FibRetracementPrimitive
   | typeof TrendlinePrimitive
+  | typeof HorizontalLinePrimitive
 type TDrawingPrimitive = TDrawingPrimitives['prototype']
 
 export type TTypeToDrawingPrimitive = {
@@ -53,6 +55,8 @@ export function importPrimitive(type: TDrawingTypes) {
   switch (type) {
     case 'trendline':
       return import('./trendline/primitive.js')
+    case 'horizontal-line':
+      return import('./horizontal-line/primitive.js')
     case 'rectangle':
       return import('./rectangle/primitive.js')
     case 'fib_retracement':

--- a/src/lib/ui/app/Chart/drawing-tools/ctx.svelte.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/ctx.svelte.ts
@@ -4,6 +4,7 @@ import type { default as FibRetracementPrimitive } from './fib-retracement/primi
 import type { default as RectanglePrimitive } from './rectangle/primitive.js'
 import type { default as TrendlinePrimitive } from './trendline/primitive.js'
 import type { default as HorizontalLinePrimitive } from './horizontal-line/primitive.js'
+import type { default as VerticalLinePrimitive } from './vertical-line/primitive.js'
 
 import { createCtx } from '$lib/utils/index.js'
 
@@ -15,6 +16,7 @@ type TDrawingPrimitives =
   | typeof FibRetracementPrimitive
   | typeof TrendlinePrimitive
   | typeof HorizontalLinePrimitive
+  | typeof VerticalLinePrimitive
 type TDrawingPrimitive = TDrawingPrimitives['prototype']
 
 export type TTypeToDrawingPrimitive = {
@@ -57,6 +59,8 @@ export function importPrimitive(type: TDrawingTypes) {
       return import('./trendline/primitive.js')
     case 'horizontal-line':
       return import('./horizontal-line/primitive.js')
+    case 'vertical-line':
+      return import('./vertical-line/primitive.js')
     case 'rectangle':
       return import('./rectangle/primitive.js')
     case 'fib_retracement':

--- a/src/lib/ui/app/Chart/drawing-tools/ctx.svelte.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/ctx.svelte.ts
@@ -2,13 +2,17 @@ import type { MouseEventParams } from '@santiment-network/chart-next'
 import type { TPoint } from './types.js'
 import type { default as FibRetracementPrimitive } from './fib-retracement/primitive.js'
 import type { default as RectanglePrimitive } from './rectangle/primitive.js'
+import type { default as TrendlinePrimitive } from './trendline/primitive.js'
 
 import { createCtx } from '$lib/utils/index.js'
 
 import { useChartCtx, useMetricSeriesCtx } from '../ctx/index.js'
 import { RenderHitTest, type TRenderHitTestData } from './_core/renderer.js'
 
-type TDrawingPrimitives = typeof RectanglePrimitive | typeof FibRetracementPrimitive
+type TDrawingPrimitives =
+  | typeof RectanglePrimitive
+  | typeof FibRetracementPrimitive
+  | typeof TrendlinePrimitive
 type TDrawingPrimitive = TDrawingPrimitives['prototype']
 
 export type TTypeToDrawingPrimitive = {
@@ -47,6 +51,8 @@ type THoveredPrimitive = {
 
 export function importPrimitive(type: TDrawingTypes) {
   switch (type) {
+    case 'trendline':
+      return import('./trendline/primitive.js')
     case 'rectangle':
       return import('./rectangle/primitive.js')
     case 'fib_retracement':

--- a/src/lib/ui/app/Chart/drawing-tools/fib-retracement/primitive.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/fib-retracement/primitive.ts
@@ -1,4 +1,4 @@
-import type { TPoint, TViewPoint } from '../types.js'
+import type { TViewPoint } from '../types.js'
 
 import { DrawingPrimitive } from '../_core/primitive.js'
 import { FibRetracementPaneView } from './pane-view.js'

--- a/src/lib/ui/app/Chart/drawing-tools/fib-retracement/renderer.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/fib-retracement/renderer.ts
@@ -1,12 +1,13 @@
 import type { CanvasRenderingTarget2D } from 'fancy-canvas'
 import type { Coordinate } from '@santiment-network/chart-next'
+import type { FibRetracementPaneView } from './pane-view.js'
+
 import {
   checkIsOutsideLine,
   RenderHitTest,
   type TPaneRenderer,
   type TRenderHitTestData,
 } from '../_core/renderer.js'
-import type { FibRetracementPaneView } from './pane-view.js'
 
 export type TRenderData = {
   levels: { color: string; level: number; value: string; y: Coordinate }[]

--- a/src/lib/ui/app/Chart/drawing-tools/horizontal-line/pane-view.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/horizontal-line/pane-view.ts
@@ -1,0 +1,32 @@
+import type { TViewPoint } from '../types.js'
+
+import { getBrowserCssVariable } from '$ui/utils/index.js'
+
+import { DrawingPaneView } from '../_core/pane-view.js'
+import { DrawingCompositePaneRenderer, HandleRenderer } from '../_core/renderer.js'
+import { HorizontalLinePaneRenderer } from './renderer.js'
+
+export class HorizontalLinePaneView extends DrawingPaneView {
+  public get viewPoints(): [TViewPoint] {
+    return this._source.viewPoints as [TViewPoint]
+  }
+
+  public strokeColor: string = getBrowserCssVariable('waterloo')
+  public isSelected: boolean = true
+
+  protected _renderer: DrawingCompositePaneRenderer = new DrawingCompositePaneRenderer([
+    new HorizontalLinePaneRenderer(this),
+
+    new HandleRenderer(this, { pointIndices: [0, 0] }),
+  ])
+
+  public update() {}
+
+  public move(diffXY: [number, number]): void {
+    this.movePoint(0, 0, 0, diffXY[1])
+  }
+
+  public renderer() {
+    return this._renderer
+  }
+}

--- a/src/lib/ui/app/Chart/drawing-tools/horizontal-line/primitive.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/horizontal-line/primitive.ts
@@ -1,0 +1,51 @@
+import type { TOptions, TPoint, TViewPoint } from '../types.js'
+
+import { DrawingPrimitive } from '../_core/primitive.js'
+import { HorizontalLinePaneView } from './pane-view.js'
+import type { Coordinate } from '@santiment-network/chart-next'
+
+export default class HorizontalLinePrimitive extends DrawingPrimitive<'horizontal-line'> {
+  public __type = 'horizontal-line' as const
+
+  protected _paneViews: HorizontalLinePaneView[] = [new HorizontalLinePaneView(this)]
+
+  public constructor(dataPoints: TPoint[], options: Partial<TOptions> = {}) {
+    super(dataPoints.slice(0, 1), options)
+
+    this._timeAxisViews.length = 0
+    this._timeAxisPaneViews.length = 0
+  }
+
+  public updateEndPoint(point: TViewPoint) {
+    this.viewPoints[this.viewPoints.length - 1] = point
+
+    this.requestUpdate()
+  }
+
+  protected mapDataPointsToViewPoints(): undefined | TViewPoint[] {
+    const series = this._series
+    if (!series) return
+
+    // @ts-expect-error
+    const x = (this.series.getPane()._pane._width / 2) as Coordinate
+
+    return this._dataPoints.map((point) => ({
+      x,
+      y: series.priceToCoordinate(point.price),
+    }))
+  }
+
+  protected mapViewPointsToDataPoints(): undefined | TPoint[] {
+    const series = this._series
+    if (!series) return
+
+    return this._viewPoints.map((point) => ({
+      time: 0 as TPoint['time'],
+      price: series.coordinateToPrice(point.y!)!,
+    }))
+  }
+
+  public select(value: boolean): void {
+    this._paneViews[0].isSelected = true
+  }
+}

--- a/src/lib/ui/app/Chart/drawing-tools/horizontal-line/renderer.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/horizontal-line/renderer.ts
@@ -1,0 +1,55 @@
+import type { CanvasRenderingTarget2D } from 'fancy-canvas'
+import type { Coordinate } from '@santiment-network/chart-next'
+import type { HorizontalLinePaneView } from './pane-view.js'
+
+import {
+  positionPoint,
+  RenderHitTest,
+  type TPaneRenderer,
+  type TRenderHitTestData,
+} from '../_core/renderer.js'
+import { drawLine } from '../trendline/renderer.js'
+
+export class HorizontalLinePaneRenderer implements TPaneRenderer {
+  private _paneView: HorizontalLinePaneView
+
+  constructor(paneView: HorizontalLinePaneView) {
+    this._paneView = paneView
+  }
+
+  draw(target: CanvasRenderingTarget2D) {
+    target.useBitmapCoordinateSpace((scope) => {
+      const p1 = this._paneView.viewPoints[0]
+
+      if (p1.y === null) {
+        return
+      }
+
+      const ctx = scope.context
+
+      ctx.save()
+
+      drawLine(
+        ctx,
+        positionPoint(0, scope.horizontalPixelRatio),
+        positionPoint(p1.y, scope.verticalPixelRatio),
+        positionPoint(scope.mediaSize.width, scope.horizontalPixelRatio),
+        positionPoint(p1.y, scope.verticalPixelRatio),
+        2 * scope.verticalPixelRatio,
+        this._paneView.strokeColor,
+      )
+
+      ctx.restore()
+    })
+  }
+
+  hitTest(_: Coordinate, y: Coordinate): TRenderHitTestData | null {
+    const [p1] = this._paneView.viewPoints
+
+    if (y < p1.y! - 2 || y > p1.y! + 2) {
+      return null
+    }
+
+    return { type: RenderHitTest.PRIMITIVE }
+  }
+}

--- a/src/lib/ui/app/Chart/drawing-tools/trendline/pane-view.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/trendline/pane-view.ts
@@ -1,0 +1,29 @@
+import type { TViewPoint } from '../types.js'
+
+import { getBrowserCssVariable } from '$ui/utils/index.js'
+
+import { DrawingPaneView } from '../_core/pane-view.js'
+import { DrawingCompositePaneRenderer, HandleRenderer } from '../_core/renderer.js'
+import { TrendlinePaneRenderer } from './renderer.js'
+
+export class TrendlinePaneView extends DrawingPaneView {
+  public get viewPoints(): [TViewPoint, TViewPoint] {
+    return this._source.viewPoints as [TViewPoint, TViewPoint]
+  }
+
+  public strokeColor: string = getBrowserCssVariable('waterloo')
+
+  protected _renderer: DrawingCompositePaneRenderer = new DrawingCompositePaneRenderer([
+    new TrendlinePaneRenderer(this),
+
+    new HandleRenderer(this, { pointIndices: [0, 0] }),
+
+    new HandleRenderer(this, { pointIndices: [1, 1] }),
+  ])
+
+  update() {}
+
+  renderer() {
+    return this._renderer
+  }
+}

--- a/src/lib/ui/app/Chart/drawing-tools/trendline/primitive.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/trendline/primitive.ts
@@ -1,0 +1,16 @@
+import type { TViewPoint } from '../types.js'
+
+import { DrawingPrimitive } from '../_core/primitive.js'
+import { TrendlinePaneView } from './pane-view.js'
+
+export default class TrendlinePrimitive extends DrawingPrimitive<'trendline'> {
+  public __type = 'trendline' as const
+
+  protected _paneViews: TrendlinePaneView[] = [new TrendlinePaneView(this)]
+
+  public updateEndPoint(point: TViewPoint) {
+    this.viewPoints[this.viewPoints.length - 1] = point
+
+    this.requestUpdate()
+  }
+}

--- a/src/lib/ui/app/Chart/drawing-tools/trendline/renderer.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/trendline/renderer.ts
@@ -29,19 +29,16 @@ export class TrendlinePaneRenderer implements TPaneRenderer {
 
       ctx.save()
 
-      ctx.beginPath()
-      ctx.moveTo(
+      drawLine(
+        ctx,
         positionPoint(p1.x, scope.horizontalPixelRatio),
         positionPoint(p1.y, scope.verticalPixelRatio),
-      )
-      ctx.lineTo(
         positionPoint(p2.x, scope.horizontalPixelRatio),
         positionPoint(p2.y, scope.verticalPixelRatio),
+        2 * scope.verticalPixelRatio,
+        this._paneView.strokeColor,
       )
-      ctx.lineWidth = 2 * scope.verticalPixelRatio
-      ctx.strokeStyle = this._paneView.strokeColor
 
-      ctx.stroke()
       ctx.restore()
     })
   }
@@ -55,4 +52,22 @@ export class TrendlinePaneRenderer implements TPaneRenderer {
 
     return { type: RenderHitTest.PRIMITIVE }
   }
+}
+
+export function drawLine(
+  ctx: CanvasRenderingContext2D,
+  x1: number,
+  y1: number,
+  x2: number,
+  y2: number,
+  width: number,
+  color: string,
+) {
+  ctx.beginPath()
+  ctx.moveTo(x1, y1)
+  ctx.lineTo(x2, y2)
+  ctx.lineWidth = width
+  ctx.strokeStyle = color
+
+  ctx.stroke()
 }

--- a/src/lib/ui/app/Chart/drawing-tools/trendline/renderer.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/trendline/renderer.ts
@@ -1,22 +1,20 @@
 import type { CanvasRenderingTarget2D } from 'fancy-canvas'
 import type { Coordinate } from '@santiment-network/chart-next'
-import type { RectanglePaneView } from './pane-view.js'
+import type { TrendlinePaneView } from './pane-view.js'
 
 import {
-  checkIsOutsideRect,
-  positionsBox,
+  checkIsOutsideLine,
+  positionPoint,
   RenderHitTest,
   type TPaneRenderer,
   type TRenderHitTestData,
 } from '../_core/renderer.js'
 
-export class RectanglePaneRenderer implements TPaneRenderer {
-  private _paneView: RectanglePaneView
-  private _fillColor: string
+export class TrendlinePaneRenderer implements TPaneRenderer {
+  private _paneView: TrendlinePaneView
 
-  constructor(paneView: RectanglePaneView, fillColor: string) {
+  constructor(paneView: TrendlinePaneView) {
     this._paneView = paneView
-    this._fillColor = fillColor
   }
 
   draw(target: CanvasRenderingTarget2D) {
@@ -28,22 +26,30 @@ export class RectanglePaneRenderer implements TPaneRenderer {
       }
 
       const ctx = scope.context
-      const horizontalPositions = positionsBox(p1.x, p2.x, scope.horizontalPixelRatio)
-      const verticalPositions = positionsBox(p1.y, p2.y, scope.verticalPixelRatio)
-      ctx.fillStyle = this._fillColor
-      ctx.fillRect(
-        horizontalPositions.position,
-        verticalPositions.position,
-        horizontalPositions.length,
-        verticalPositions.length,
+
+      ctx.save()
+
+      ctx.beginPath()
+      ctx.moveTo(
+        positionPoint(p1.x, scope.horizontalPixelRatio),
+        positionPoint(p1.y, scope.verticalPixelRatio),
       )
+      ctx.lineTo(
+        positionPoint(p2.x, scope.horizontalPixelRatio),
+        positionPoint(p2.y, scope.verticalPixelRatio),
+      )
+      ctx.lineWidth = 2 * scope.verticalPixelRatio
+      ctx.strokeStyle = this._paneView.strokeColor
+
+      ctx.stroke()
+      ctx.restore()
     })
   }
 
   hitTest(x: Coordinate, y: Coordinate): TRenderHitTestData | null {
     const [p1, p2] = this._paneView.viewPoints
 
-    if (checkIsOutsideRect(x, y, p1.x, p2.x, p1.y, p2.y)) {
+    if (checkIsOutsideLine(x, y, p1, p2)) {
       return null
     }
 

--- a/src/lib/ui/app/Chart/drawing-tools/vertical-line/pane-view.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/vertical-line/pane-view.ts
@@ -1,0 +1,32 @@
+import type { TViewPoint } from '../types.js'
+
+import { getBrowserCssVariable } from '$ui/utils/index.js'
+
+import { DrawingPaneView } from '../_core/pane-view.js'
+import { DrawingCompositePaneRenderer, HandleRenderer } from '../_core/renderer.js'
+import { VerticalLinePaneRenderer } from './renderer.js'
+
+export class VerticalLinePaneView extends DrawingPaneView {
+  public get viewPoints(): [TViewPoint] {
+    return this._source.viewPoints as [TViewPoint]
+  }
+
+  public strokeColor: string = getBrowserCssVariable('waterloo')
+  public isSelected: boolean = true
+
+  protected _renderer: DrawingCompositePaneRenderer = new DrawingCompositePaneRenderer([
+    new VerticalLinePaneRenderer(this),
+
+    new HandleRenderer(this, { pointIndices: [0, 0] }),
+  ])
+
+  public update() {}
+
+  public move(diffXY: [number, number]): void {
+    this.movePoint(0, 0, diffXY[0], 0)
+  }
+
+  public renderer() {
+    return this._renderer
+  }
+}

--- a/src/lib/ui/app/Chart/drawing-tools/vertical-line/primitive.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/vertical-line/primitive.ts
@@ -2,18 +2,18 @@ import type { TOptions, TPoint, TViewPoint } from '../types.js'
 import type { Coordinate } from '@santiment-network/chart-next'
 
 import { DrawingPrimitive } from '../_core/primitive.js'
-import { HorizontalLinePaneView } from './pane-view.js'
+import { VerticalLinePaneView } from './pane-view.js'
 
-export default class HorizontalLinePrimitive extends DrawingPrimitive<'horizontal-line'> {
-  public __type = 'horizontal-line' as const
+export default class VerticalLinePrimitive extends DrawingPrimitive<'vertical-line'> {
+  public __type = 'vertical-line' as const
 
-  protected _paneViews: HorizontalLinePaneView[] = [new HorizontalLinePaneView(this)]
+  protected _paneViews: VerticalLinePaneView[] = [new VerticalLinePaneView(this)]
 
   public constructor(dataPoints: TPoint[], options: Partial<TOptions> = {}) {
     super(dataPoints.slice(0, 1), options)
 
-    this._timeAxisViews.length = 0
-    this._timeAxisPaneViews.length = 0
+    this._priceAxisViews.length = 0
+    this._priceAxisPaneViews.length = 0
   }
 
   public updateEndPoint(point: TViewPoint) {
@@ -23,25 +23,23 @@ export default class HorizontalLinePrimitive extends DrawingPrimitive<'horizonta
   }
 
   protected mapDataPointsToViewPoints(): undefined | TViewPoint[] {
-    const series = this._series
-    if (!series) return
+    const timeScale = this.chart.timeScale()
 
     // @ts-expect-error
-    const x = (this.series.getPane()._pane._width / 2) as Coordinate
+    const y = (this.series.getPane()._pane._height / 2) as Coordinate
 
     return this._dataPoints.map((point) => ({
-      x,
-      y: series.priceToCoordinate(point.price),
+      x: timeScale.timeToCoordinate(point.time),
+      y,
     }))
   }
 
   protected mapViewPointsToDataPoints(): undefined | TPoint[] {
-    const series = this._series
-    if (!series) return
+    const timeScale = this.chart.timeScale()
 
     return this._viewPoints.map((point) => ({
-      time: 0 as TPoint['time'],
-      price: series.coordinateToPrice(point.y!)!,
+      time: timeScale.coordinateToTime(point.x!)!,
+      price: 0,
     }))
   }
 

--- a/src/lib/ui/app/Chart/drawing-tools/vertical-line/renderer.ts
+++ b/src/lib/ui/app/Chart/drawing-tools/vertical-line/renderer.ts
@@ -1,0 +1,55 @@
+import type { CanvasRenderingTarget2D } from 'fancy-canvas'
+import type { Coordinate } from '@santiment-network/chart-next'
+import type { VerticalLinePaneView } from './pane-view.js'
+
+import {
+  positionPoint,
+  RenderHitTest,
+  type TPaneRenderer,
+  type TRenderHitTestData,
+} from '../_core/renderer.js'
+import { drawLine } from '../trendline/renderer.js'
+
+export class VerticalLinePaneRenderer implements TPaneRenderer {
+  private _paneView: VerticalLinePaneView
+
+  constructor(paneView: VerticalLinePaneView) {
+    this._paneView = paneView
+  }
+
+  draw(target: CanvasRenderingTarget2D) {
+    target.useBitmapCoordinateSpace((scope) => {
+      const p1 = this._paneView.viewPoints[0]
+
+      if (p1.y === null) {
+        return
+      }
+
+      const ctx = scope.context
+
+      ctx.save()
+
+      drawLine(
+        ctx,
+        positionPoint(p1.x!, scope.horizontalPixelRatio),
+        positionPoint(0, scope.verticalPixelRatio),
+        positionPoint(p1.x!, scope.horizontalPixelRatio),
+        positionPoint(scope.mediaSize.height, scope.verticalPixelRatio),
+        2 * scope.verticalPixelRatio,
+        this._paneView.strokeColor,
+      )
+
+      ctx.restore()
+    })
+  }
+
+  hitTest(x: Coordinate, _: Coordinate): TRenderHitTestData | null {
+    const [p1] = this._paneView.viewPoints
+
+    if (x < p1.x! - 2 || x > p1.x! + 2) {
+      return null
+    }
+
+    return { type: RenderHitTest.PRIMITIVE }
+  }
+}

--- a/src/stories/Design System - App UI/Chart/DrawingTools.svelte
+++ b/src/stories/Design System - App UI/Chart/DrawingTools.svelte
@@ -7,6 +7,7 @@
 </script>
 
 <div class="flex gap-2">
+  {@render button(['trendline', 'T.Line'])}
   {@render button(['rectangle', 'Rect'])}
   {@render button(['fib_retracement', 'Fib'])}
 </div>

--- a/src/stories/Design System - App UI/Chart/DrawingTools.svelte
+++ b/src/stories/Design System - App UI/Chart/DrawingTools.svelte
@@ -9,6 +9,7 @@
 <div class="flex gap-2">
   {@render button(['trendline', 'T.Line'])}
   {@render button(['horizontal-line', 'H.Line'])}
+  {@render button(['vertical-line', 'V.Line'])}
   {@render button(['rectangle', 'Rect'])}
   {@render button(['fib_retracement', 'Fib'])}
 </div>

--- a/src/stories/Design System - App UI/Chart/DrawingTools.svelte
+++ b/src/stories/Design System - App UI/Chart/DrawingTools.svelte
@@ -8,6 +8,7 @@
 
 <div class="flex gap-2">
   {@render button(['trendline', 'T.Line'])}
+  {@render button(['horizontal-line', 'H.Line'])}
   {@render button(['rectangle', 'Rect'])}
   {@render button(['fib_retracement', 'Fib'])}
 </div>


### PR DESCRIPTION
# Summary
The `Trendline`, `Horizontal Line`, `Vertical Line` implemented using new drawing core primitives with interactive handles support.
TODO: Update trendline hit-test algo, since it doesn't work well when the chart is zoomed in (using cmd+scroll).

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 5 in a stack** made with GitButler:
- <kbd>&nbsp;5&nbsp;</kbd> #409 👈 
- <kbd>&nbsp;4&nbsp;</kbd> #408
- <kbd>&nbsp;3&nbsp;</kbd> #407
- <kbd>&nbsp;2&nbsp;</kbd> #406
- <kbd>&nbsp;1&nbsp;</kbd> #405
<!-- GitButler Footer Boundary Bottom -->