### PR TITLE
feat(notifications) Add custom notification type with user-specified icon

### DIFF
--- a/src/lib/ui/core/Notifications/Notification.svelte
+++ b/src/lib/ui/core/Notifications/Notification.svelte
@@ -1,13 +1,15 @@
 <script lang="ts">
-  import { createEventDispatcher, onMount, type Snippet } from 'svelte'
+  import { createEventDispatcher, onMount, type ComponentProps, type Snippet } from 'svelte'
 
   import Button from '$ui/core/Button/index.js'
   import Svg from '$ui/core/Svg/index.js'
   import { cn } from '$ui/utils/index.js'
   import { useUiCtx } from '$lib/ctx/ui/index.svelte.js'
 
+  type SvgProps = ComponentProps<typeof Svg>
+
   type Props = {
-    icon: 'info' | 'checkmark-circle' | 'warning' | 'error'
+    icon: SvgProps['id']
     message: string
     content?: string | Snippet<[{ close: () => void }]>
     action?: { label: string; onClick?: (close: () => void) => void; href?: string }
@@ -22,7 +24,7 @@
 
   const close = () => dispatch('closeToast')
 
-  const ICONS = {
+  const ICONS: Record<string, Partial<SvgProps>> = {
     info: { class: 'fill-waterloo' },
     'checkmark-circle': { class: 'fill-green' },
     warning: { class: 'fill-orange', h: 14 },

--- a/src/lib/ui/core/Notifications/index.ts
+++ b/src/lib/ui/core/Notifications/index.ts
@@ -21,14 +21,13 @@ const createNotificationType =
   (...rest: [message: string, options?: TOptions]) =>
     createToast(icon, ...rest)
 
-const notification: Record<
-  'info' | 'error' | 'warning' | 'success',
-  (message: string, options?: TOptions) => string | number
-> = {
+const notification = {
   info: createNotificationType('info'),
   error: createNotificationType('error'),
   warning: createNotificationType('warning'),
   success: createNotificationType('checkmark-circle'),
+  custom: (icon: TIcon, message: string, options?: TOptions) =>
+    createNotificationType(icon)(message, options),
 }
 
 export { notification }

--- a/src/stories/Design System - Core UI/Notifications/index.svelte
+++ b/src/stories/Design System - Core UI/Notifications/index.svelte
@@ -21,6 +21,7 @@
   <Notification icon="warning" message="Warning notification"></Notification>
   <Notification icon="error" message="Error notification"></Notification>
   <Notification icon="error" message="Error notification"></Notification>
+  <Notification icon="star" message="Custom notification" class="fill-yellow"></Notification>
 
   <Notification
     icon="info"
@@ -112,5 +113,12 @@
     <Button variant="border" onclick={() => notification.error('Event has been created')}
       >Error</Button
     >
+
+    <Button
+      variant="border"
+      onclick={() => notification.custom('fire', 'Event has been created', { class: 'fill-red' })}
+    >
+      Custom Fire
+    </Button>
   </div>
 </div>


### PR DESCRIPTION
## Summary

Add custom notification type with user-specified icon

## Notion card
https://www.notion.so/santiment/Notification-Centre-1st-iter-2b72a82d1361809e89bfedbbe8f51c6b?source=copy_link