### PR TITLE
feat(analytics): add Affiliatly conversion tracking

### DIFF
--- a/src/lib/analytics/affiliatly/index.ts
+++ b/src/lib/analytics/affiliatly/index.ts
@@ -1,12 +1,29 @@
 import { newHeadScript } from '../utils.js'
 
-export function initAffiliatly(id: string = 'AF-1074422') {
+const DEFAULT_ID = 'AF-1074422'
+
+function loadAffiliatlyScript(params: string, id = DEFAULT_ID) {
+  newHeadScript(undefined, {
+    src: `https://static.affiliatly.com/v3/affiliatly.js?affiliatly_code=${id}${params}`,
+  })
+}
+
+function trackConversion(orderPrice: number) {
+  loadAffiliatlyScript(`&conversion=1&id_order=${Date.now()}&order_price=${orderPrice}`)
+}
+
+export function trackAffiliatlySignup() {
+  trackConversion(0)
+}
+
+export function trackAffiliatlyPayment(price: number) {
+  trackConversion(price)
+}
+
+export function initAffiliatly(id?: string) {
   if (process.env.IS_LOGGING_ENABLED) return
 
-  const load = () =>
-    newHeadScript(undefined, {
-      src: `https://static.affiliatly.com/v3/affiliatly.js?affiliatly_code=${id}`,
-    })
+  const load = () => loadAffiliatlyScript('', id)
 
   if (document.readyState === 'complete') {
     load()

--- a/src/lib/analytics/affiliatly/index.ts
+++ b/src/lib/analytics/affiliatly/index.ts
@@ -1,33 +1,32 @@
-import { newHeadScript } from '../utils.js'
+export const AFFILIATLY_PROXY_ROUTE = '/api/track/affiliatly'
 
-const DEFAULT_ID = 'AF-1074422'
+type TConversionOptions = {
+  couponCode?: string
+  clientEmail?: string
+}
 
-function loadAffiliatlyScript(params: string, id = DEFAULT_ID) {
-  newHeadScript(undefined, {
-    src: `https://static.affiliatly.com/v3/affiliatly.js?affiliatly_code=${id}${params}`,
+async function reportConversion(
+  order: string | number,
+  price: number,
+  options?: TConversionOptions,
+) {
+  const payload = new URLSearchParams({
+    order: String(order),
+    price: String(price),
   })
+
+  if (options?.couponCode) payload.append('coupon_code', options.couponCode)
+  if (options?.clientEmail) payload.append('client_email', options.clientEmail)
+
+  await fetch(AFFILIATLY_PROXY_ROUTE, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: payload,
+    credentials: 'same-origin',
+  }).catch((error) => console.error(error))
 }
 
-function trackConversion(orderPrice: number) {
-  loadAffiliatlyScript(`&conversion=1&id_order=${Date.now()}&order_price=${orderPrice}`)
-}
+export const trackAffiliatlySignup = () => reportConversion(crypto.randomUUID(), 0)
 
-export function trackAffiliatlySignup() {
-  trackConversion(0)
-}
-
-export function trackAffiliatlyPayment(price: number) {
-  trackConversion(price)
-}
-
-export function initAffiliatly(id?: string) {
-  if (process.env.IS_LOGGING_ENABLED) return
-
-  const load = () => loadAffiliatlyScript('', id)
-
-  if (document.readyState === 'complete') {
-    load()
-  } else {
-    window.addEventListener('load', load)
-  }
-}
+export const trackAffiliatlyPayment = (amount: number, options?: TConversionOptions) =>
+  reportConversion(crypto.randomUUID(), amount, options)

--- a/src/lib/analytics/affiliatly/index.ts
+++ b/src/lib/analytics/affiliatly/index.ts
@@ -26,7 +26,10 @@ async function reportConversion(
   }).catch((error) => console.error(error))
 }
 
-export const trackAffiliatlySignup = () => reportConversion(crypto.randomUUID(), 0)
+export const trackAffiliatlySignup = (userId: string | number) => reportConversion(userId, 0)
 
-export const trackAffiliatlyPayment = (amount: number, options?: TConversionOptions) =>
-  reportConversion(crypto.randomUUID(), amount, options)
+export const trackAffiliatlyPayment = (
+  orderId: string | number,
+  amount: number,
+  options?: TConversionOptions,
+) => reportConversion(orderId, amount, options)

--- a/src/lib/sveltekit/hooks/affiliatly.ts
+++ b/src/lib/sveltekit/hooks/affiliatly.ts
@@ -22,6 +22,10 @@ const TRACKING_QUERY_KEYS = [
 
 const UTM_KEYS = ['utm_campaign', 'utm_content', 'utm_medium', 'utm_source', 'utm_term'] as const
 
+const LEGACY_AFFILIATE_MAP: Record<string, string> = {
+  twitter: '2',
+}
+
 function extractParams(url: URL, keys: readonly string[], prefix = '') {
   const result: Record<string, string> = {}
 
@@ -79,6 +83,12 @@ export const affiliatlyTrackHandle: Handle = async ({ event, resolve }) => {
   const { url, cookies, request } = event
 
   const affiliateParams = extractParams(url, TRACKING_QUERY_KEYS)
+
+  const fpr = url.searchParams.get('fpr')
+
+  if (fpr && LEGACY_AFFILIATE_MAP[fpr] && !affiliateParams.aff) {
+    affiliateParams.aff = LEGACY_AFFILIATE_MAP[fpr]
+  }
 
   if (affiliateParams['coupon-code']) {
     affiliateParams.couponcode = affiliateParams['coupon-code']

--- a/src/lib/sveltekit/hooks/affiliatly.ts
+++ b/src/lib/sveltekit/hooks/affiliatly.ts
@@ -1,0 +1,138 @@
+import { type Handle, type RequestEvent } from '@sveltejs/kit'
+
+import { AFFILIATLY_PROXY_ROUTE } from '$lib/analytics/affiliatly/index.js'
+
+const API_ENDPOINT = 'https://www.affiliatly.com/api_request.php'
+const COOKIE_NAME = 'affiliatly_v3'
+const PROGRAM_ID = 'AF-1074422'
+
+const DEFAULT_COOKIE_MAX_AGE = 60 * 60 * 24 * 30
+
+const TRACKING_QUERY_KEYS = [
+  'aff',
+  'fid',
+  'ref',
+  'air',
+  'rfsn',
+  'aa',
+  'tr',
+  'abc',
+  'coupon-code',
+  'hair',
+] as const
+
+const UTM_KEYS = ['utm_campaign', 'utm_content', 'utm_medium', 'utm_source', 'utm_term'] as const
+
+function extractParams(url: URL, keys: readonly string[], prefix = '') {
+  const result: Record<string, string> = {}
+
+  for (const key of keys) {
+    const value = url.searchParams.get(key)
+    if (value) result[key.replace(prefix, '')] = value
+  }
+
+  return result
+}
+
+async function callAffiliatly(payload: URLSearchParams) {
+  const query = new URLSearchParams({ aid: PROGRAM_ID, t: Date.now().toString() })
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), 2000)
+
+  return fetch(`${API_ENDPOINT}?${query}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: payload,
+    signal: controller.signal,
+  })
+    .catch((error) => console.error(error))
+    .finally(() => clearTimeout(timeout))
+}
+
+function parseAffiliateCookie(cookieValue: string) {
+  const params = new URLSearchParams(cookieValue)
+
+  const idToken = params.get('id_token')
+  const userId = params.get('id_user')
+  const affiliateUserId = params.get('aff_uid') ?? ''
+
+  return idToken && userId ? { idToken, userId, affiliateUserId } : null
+}
+
+async function handleConversionProxy(event: RequestEvent) {
+  const cookieValue = event.cookies.get(COOKIE_NAME)
+  const session = cookieValue ? parseAffiliateCookie(cookieValue) : null
+
+  if (!session) return new Response(null, { status: 204 })
+
+  const body = await event.request.text()
+  const formData = new URLSearchParams(body)
+
+  await callAffiliatly(
+    new URLSearchParams({
+      mode: 'mark',
+      id_affiliatly: PROGRAM_ID,
+      id_user: session.userId,
+      id_hash: session.idToken,
+      aff_uid: session.affiliateUserId,
+      order: formData.get('order') ?? '',
+      price: formData.get('price') ?? '',
+      coupon_code: formData.get('coupon_code') ?? '',
+      client_email: formData.get('client_email') ?? '',
+    }),
+  )
+
+  return new Response(null, { status: 204 })
+}
+
+async function saveAffiliateCookie(response: Response | void, cookies: RequestEvent['cookies']) {
+  if (!response?.ok) return
+
+  const rawData = await response.text()
+  if (!rawData) return
+
+  const durationStr = new URLSearchParams(rawData).get('duration')
+  const maxAge = parseInt(durationStr ?? String(DEFAULT_COOKIE_MAX_AGE), 10)
+
+  cookies.set(COOKIE_NAME, rawData, {
+    path: '/',
+    maxAge,
+    sameSite: 'lax',
+    httpOnly: true,
+  })
+}
+
+export const affiliatlyHandle: Handle = async ({ event, resolve }) => {
+  const { url, cookies, request } = event
+
+  if (url.pathname === AFFILIATLY_PROXY_ROUTE && request.method === 'POST') {
+    return handleConversionProxy(event)
+  }
+
+  const affiliateParams = extractParams(url, TRACKING_QUERY_KEYS)
+
+  if (affiliateParams['coupon-code']) {
+    affiliateParams.couponcode = affiliateParams['coupon-code']
+    delete affiliateParams['coupon-code']
+  }
+
+  const hasParams = Object.keys(affiliateParams).length > 0
+  const hasCookie = cookies.get(COOKIE_NAME) !== undefined
+
+  if (hasCookie || !hasParams) return resolve(event)
+
+  const payload = new URLSearchParams({
+    mode: 'track-v3',
+    id_affiliatly: PROGRAM_ID,
+    referer: request.headers.get('referer') ?? '',
+    tracking_parameter: JSON.stringify({ get: affiliateParams, hash: {} }),
+    utm_parameters: JSON.stringify(extractParams(url, UTM_KEYS, 'utm_')),
+  })
+
+  if (url.searchParams.has('qr')) payload.append('qr', '1')
+
+  const response = await callAffiliatly(payload)
+  await saveAffiliateCookie(response, cookies)
+
+  return resolve(event)
+}

--- a/src/lib/sveltekit/hooks/affiliatly.ts
+++ b/src/lib/sveltekit/hooks/affiliatly.ts
@@ -1,10 +1,9 @@
-import { type Handle, type RequestEvent } from '@sveltejs/kit'
-
-import { AFFILIATLY_PROXY_ROUTE } from '$lib/analytics/affiliatly/index.js'
+import { type Handle, type RequestEvent, type RequestHandler } from '@sveltejs/kit'
 
 const API_ENDPOINT = 'https://www.affiliatly.com/api_request.php'
-const COOKIE_NAME = 'affiliatly_v3'
-const PROGRAM_ID = 'AF-1074422'
+
+export const AFFILIATLY_COOKIE_NAME = 'affiliatly_v3'
+export const AFFILIATLY_PROGRAM_ID = 'AF-1074422'
 
 const DEFAULT_COOKIE_MAX_AGE = 60 * 60 * 24 * 30
 
@@ -34,8 +33,8 @@ function extractParams(url: URL, keys: readonly string[], prefix = '') {
   return result
 }
 
-async function callAffiliatly(payload: URLSearchParams) {
-  const query = new URLSearchParams({ aid: PROGRAM_ID, t: Date.now().toString() })
+export async function callAffiliatly(payload: URLSearchParams) {
+  const query = new URLSearchParams({ aid: AFFILIATLY_PROGRAM_ID, t: Date.now().toString() })
   const controller = new AbortController()
   const timeout = setTimeout(() => controller.abort(), 2000)
 
@@ -49,7 +48,7 @@ async function callAffiliatly(payload: URLSearchParams) {
     .finally(() => clearTimeout(timeout))
 }
 
-function parseAffiliateCookie(cookieValue: string) {
+export function parseAffiliateCookie(cookieValue: string) {
   const params = new URLSearchParams(cookieValue)
 
   const idToken = params.get('id_token')
@@ -57,32 +56,6 @@ function parseAffiliateCookie(cookieValue: string) {
   const affiliateUserId = params.get('aff_uid') ?? ''
 
   return idToken && userId ? { idToken, userId, affiliateUserId } : null
-}
-
-async function handleConversionProxy(event: RequestEvent) {
-  const cookieValue = event.cookies.get(COOKIE_NAME)
-  const session = cookieValue ? parseAffiliateCookie(cookieValue) : null
-
-  if (!session) return new Response(null, { status: 204 })
-
-  const body = await event.request.text()
-  const formData = new URLSearchParams(body)
-
-  await callAffiliatly(
-    new URLSearchParams({
-      mode: 'mark',
-      id_affiliatly: PROGRAM_ID,
-      id_user: session.userId,
-      id_hash: session.idToken,
-      aff_uid: session.affiliateUserId,
-      order: formData.get('order') ?? '',
-      price: formData.get('price') ?? '',
-      coupon_code: formData.get('coupon_code') ?? '',
-      client_email: formData.get('client_email') ?? '',
-    }),
-  )
-
-  return new Response(null, { status: 204 })
 }
 
 async function saveAffiliateCookie(response: Response | void, cookies: RequestEvent['cookies']) {
@@ -94,7 +67,7 @@ async function saveAffiliateCookie(response: Response | void, cookies: RequestEv
   const durationStr = new URLSearchParams(rawData).get('duration')
   const maxAge = parseInt(durationStr ?? String(DEFAULT_COOKIE_MAX_AGE), 10)
 
-  cookies.set(COOKIE_NAME, rawData, {
+  cookies.set(AFFILIATLY_COOKIE_NAME, rawData, {
     path: '/',
     maxAge,
     sameSite: 'lax',
@@ -102,12 +75,8 @@ async function saveAffiliateCookie(response: Response | void, cookies: RequestEv
   })
 }
 
-export const affiliatlyHandle: Handle = async ({ event, resolve }) => {
+export const affiliatlyTrackHandle: Handle = async ({ event, resolve }) => {
   const { url, cookies, request } = event
-
-  if (url.pathname === AFFILIATLY_PROXY_ROUTE && request.method === 'POST') {
-    return handleConversionProxy(event)
-  }
 
   const affiliateParams = extractParams(url, TRACKING_QUERY_KEYS)
 
@@ -117,13 +86,13 @@ export const affiliatlyHandle: Handle = async ({ event, resolve }) => {
   }
 
   const hasParams = Object.keys(affiliateParams).length > 0
-  const hasCookie = cookies.get(COOKIE_NAME) !== undefined
+  const hasCookie = cookies.get(AFFILIATLY_COOKIE_NAME) !== undefined
 
   if (hasCookie || !hasParams) return resolve(event)
 
   const payload = new URLSearchParams({
     mode: 'track-v3',
-    id_affiliatly: PROGRAM_ID,
+    id_affiliatly: AFFILIATLY_PROGRAM_ID,
     referer: request.headers.get('referer') ?? '',
     tracking_parameter: JSON.stringify({ get: affiliateParams, hash: {} }),
     utm_parameters: JSON.stringify(extractParams(url, UTM_KEYS, 'utm_')),
@@ -135,4 +104,31 @@ export const affiliatlyHandle: Handle = async ({ event, resolve }) => {
   await saveAffiliateCookie(response, cookies)
 
   return resolve(event)
+}
+
+export function createAffiliatlyConversionHandler(): RequestHandler {
+  return async ({ request, cookies }) => {
+    const cookieValue = cookies.get(AFFILIATLY_COOKIE_NAME)
+    const session = cookieValue ? parseAffiliateCookie(cookieValue) : null
+
+    if (!session) return new Response(null, { status: 204 })
+
+    const formData = new URLSearchParams(await request.text())
+
+    await callAffiliatly(
+      new URLSearchParams({
+        mode: 'mark',
+        id_affiliatly: AFFILIATLY_PROGRAM_ID,
+        id_user: session.userId,
+        id_hash: session.idToken,
+        aff_uid: session.affiliateUserId,
+        order: formData.get('order') ?? '',
+        price: formData.get('price') ?? '',
+        coupon_code: formData.get('coupon_code') ?? '',
+        client_email: formData.get('client_email') ?? '',
+      }),
+    )
+
+    return new Response(null, { status: 204 })
+  }
 }

--- a/src/lib/sveltekit/hooks/index.ts
+++ b/src/lib/sveltekit/hooks/index.ts
@@ -67,4 +67,4 @@ export { cookiePolicyHandle } from './cookie.js'
 
 export { posthogTrackHandle } from './posthog.js'
 
-export { affiliatlyHandle } from './affiliatly.js'
+export { affiliatlyTrackHandle, createAffiliatlyConversionHandler } from './affiliatly.js'

--- a/src/lib/sveltekit/hooks/index.ts
+++ b/src/lib/sveltekit/hooks/index.ts
@@ -66,3 +66,5 @@ export { sanbaseVersionHandle } from './sanbase.js'
 export { cookiePolicyHandle } from './cookie.js'
 
 export { posthogTrackHandle } from './posthog.js'
+
+export { affiliatlyHandle } from './affiliatly.js'

--- a/src/lib/ui/app/PaymentForm/api.ts
+++ b/src/lib/ui/app/PaymentForm/api.ts
@@ -14,7 +14,7 @@ export const mutateSubscribe = ApiMutation(
       id
       trialEnd
       status
-      paymentIntent { status clientSecret }
+      paymentIntent { id status clientSecret }
       plan {
         id
         name
@@ -34,6 +34,7 @@ export const mutateSubscribe = ApiMutation(
       trialEnd: null | string
       status: string
       paymentIntent: null | {
+        id: string
         status: string
         clientSecret: string
       }

--- a/src/lib/ui/app/PaymentForm/flow.ts
+++ b/src/lib/ui/app/PaymentForm/flow.ts
@@ -210,7 +210,13 @@ export function usePaymentFlow() {
         notification.success(`You have successfully upgraded to the "${planDisplayName}" plan!`)
 
         trackEvent('payment_success', analytics)
-        trackAffiliatlyPayment(Math.ceil(plan.amount / 100))
+
+        if (subscription?.paymentIntent?.id) {
+          trackAffiliatlyPayment(
+            subscription.paymentIntent.id,
+            Math.ceil((subscription.plan?.amount ?? plan.amount) / 100),
+          )
+        }
 
         return subscription
       })

--- a/src/lib/ui/app/PaymentForm/flow.ts
+++ b/src/lib/ui/app/PaymentForm/flow.ts
@@ -6,6 +6,7 @@ import { useStripeCtx } from '$lib/ctx/stripe/index.js'
 import { notification } from '$ui/core/Notifications/index.js'
 import { useCustomerCtx } from '$lib/ctx/customer/index.js'
 import { trackEvent } from '$lib/analytics/index.js'
+import { trackAffiliatlyPayment } from '$lib/analytics/affiliatly/index.js'
 
 import { mutateSubscribe } from './api.js'
 import { usePaymentFormCtx } from './state.js'
@@ -209,6 +210,7 @@ export function usePaymentFlow() {
         notification.success(`You have successfully upgraded to the "${planDisplayName}" plan!`)
 
         trackEvent('payment_success', analytics)
+        trackAffiliatlyPayment(Math.ceil(plan.amount / 100))
 
         return subscription
       })

--- a/src/lib/utils/cookies.ts
+++ b/src/lib/utils/cookies.ts
@@ -5,7 +5,7 @@ export function getCookie(name: string, predicate?: (keyValue: string) => boolea
     predicate ? predicate(keyValue) : keyValue.startsWith(name),
   )
 
-  return keyValue && keyValue.split('=')[1]
+  return keyValue && keyValue.slice(keyValue.indexOf('=') + 1)
 }
 
 export function setCookie<GValue extends number | boolean | string>(


### PR DESCRIPTION
### Description

1. Previous integration loaded a third-party script client-side was blocked by adblockers, so I replaced integration with SvelteKit hook
2. Added conversion tracking
3. Added FirstPromoter bridge

