### PR TITLE
fix(pricing) Update historical restriction for sanbase max

### DIFF
--- a/src/lib/ui/app/SubscriptionPlan/BreakdownTable/breakdown.ts
+++ b/src/lib/ui/app/SubscriptionPlan/BreakdownTable/breakdown.ts
@@ -277,7 +277,7 @@ export const SubscriptionPlanBreakdown: Record<
   [SubscriptionPlan.MAX.key]: {
     'Custom Alerts': 20,
 
-    'Historical data restriction': '1 year',
+    'Historical data restriction': '2 years',
     'Realtime restriction for restricted metrics': 'No restriction',
     'API calls / minute': '100 API calls / min',
     'API calls / hour': '4K API calls / hour',


### PR DESCRIPTION
## Summary
Fix historical data restriction in pricing breakdown: `1 year` -> `2 years`