### PR TITLE
fix/chart-restrictions-mobile

### DIFF
--- a/src/lib/ui/app/Chart/RestrictedDataDialog/RestrictedDataDialog.svelte
+++ b/src/lib/ui/app/Chart/RestrictedDataDialog/RestrictedDataDialog.svelte
@@ -26,7 +26,7 @@
   })
 </script>
 
-<Dialog class="max-w-[480px] column">
+<Dialog class="max-w-[480px] column md:mx-auto md:h-max sm:max-w-full">
   <h2 class="flex items-center justify-between border-b px-5 py-3 text-base">
     Restricted data
 

--- a/src/stories/Design System - App UI/RestrictedDataDialog/index.stories.ts
+++ b/src/stories/Design System - App UI/RestrictedDataDialog/index.stories.ts
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/svelte'
+import component from './index.svelte'
+
+const meta = {
+  component,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<component>
+type Story = StoryObj<typeof meta>
+
+export default meta
+
+export const PlanChangeDialog: Story = {
+  parameters: {},
+}

--- a/src/stories/Design System - App UI/RestrictedDataDialog/index.svelte
+++ b/src/stories/Design System - App UI/RestrictedDataDialog/index.svelte
@@ -1,0 +1,44 @@
+<script lang="ts">
+  import { useMetricsRestrictionsCtx } from '$lib/ctx/metrics-registry/index.js'
+  import type { TChartMetric } from '$lib/ctx/metrics-registry/types/index.js'
+  import { useMetricSeriesCtx } from '$ui/app/Chart/ctx/series.svelte.js'
+  import RestrictedDataDialog, {
+    useChartPlanRestrictionsCtx,
+  } from '$ui/app/Chart/RestrictedDataDialog/index.js'
+  import StoryDialog from '../../Design System - Core UI/Dialog/StoryDialog.svelte'
+
+  const METRICS: TChartMetric[] = [
+    {
+      apiMetricName: 'social_volume_total',
+      type: 'asset_metric',
+    },
+    {
+      apiMetricName: 'social_dominance_total',
+      type: 'asset_metric',
+    },
+    {
+      apiMetricName: 'price_usd',
+      type: 'asset_metric',
+    },
+    {
+      apiMetricName: 'sentiment_positive_total',
+      type: 'asset_metric',
+    },
+    {
+      apiMetricName: 'sentiment_negative_total',
+      type: 'asset_metric',
+    },
+  ]
+
+  useMetricSeriesCtx.set(METRICS)
+  useMetricsRestrictionsCtx.set()
+  const { chartPlanRestrictions } = useChartPlanRestrictionsCtx()
+</script>
+
+<div class="flex flex-col justify-center divide-y p-6">
+  <div class="flex gap-4">
+    <button onclick={() => chartPlanRestrictions.showDialog({ source: 'storybook' })}>Open</button>
+  </div>
+</div>
+
+<StoryDialog render={RestrictedDataDialog}></StoryDialog>


### PR DESCRIPTION
## Summary
1. Add storybook entry for `RestrictedDataDialog`
2. Adapt `RectrictedDataDialog` for mobile devices

## Notion card
https://www.notion.so/santiment/Modern-charts-Mobile-version-3602a82d136180909f00f69623064e02?source=copy_link