### PR TITLE
fix(tooltip) Close tooltip when click outside of its content by default, add prop to invert this behavior

### DIFF
--- a/src/lib/ui/core/Tooltip/Tooltip.svelte
+++ b/src/lib/ui/core/Tooltip/Tooltip.svelte
@@ -34,7 +34,7 @@
     position = 'bottom-end',
     positionConfig,
     offset,
-    closeOnOutsideClick = true,
+    closeOnOutsideClick = false,
     ...options
   }: Props = $props()
 
@@ -65,17 +65,17 @@
 
   let contentEl = $state<HTMLElement>()
 
-  $effect(() => {
-    if (!closeOnOutsideClick || !$open) return
-
-    const removeListener = on(window, 'pointerdown', (e) => {
-      if (contentEl && e.composedPath().includes(contentEl)) return
-
-      open.set(false)
+  if (closeOnOutsideClick) {
+    $effect(() => {
+      if (!$open) return
+  
+      return on(window, 'pointerdown', (e) => {
+        if (contentEl && e.composedPath().includes(contentEl)) return
+  
+        open.set(false)
+      })
     })
-
-    return () => removeListener()
-  })
+  }
 
   $effect(() => {
     open.set(isOpened)

--- a/src/lib/ui/core/Tooltip/Tooltip.svelte
+++ b/src/lib/ui/core/Tooltip/Tooltip.svelte
@@ -2,6 +2,7 @@
   import { type Snippet } from 'svelte'
   import { createTooltip, type CreateTooltipProps } from '@melt-ui/svelte'
   import { ss } from 'svelte-runes'
+  import { on } from 'svelte/events'
 
   import { cn } from '$ui/utils/index.js'
   import { useMelt } from '$ui/utils/melt-ui.js'
@@ -20,6 +21,7 @@
     position?: FloatingConfig['placement']
     offset?: number
     positionConfig?: FloatingConfig
+    closeOnOutsideClick?: boolean
   } & Omit<CreateTooltipProps, 'positioning'>
 
   let {
@@ -32,6 +34,7 @@
     position = 'bottom-end',
     positionConfig,
     offset,
+    closeOnOutsideClick = true,
     ...options
   }: Props = $props()
 
@@ -60,6 +63,20 @@
 
   useMelt(triggerRef, trigger)
 
+  let contentEl = $state<HTMLElement>()
+
+  $effect(() => {
+    if (!closeOnOutsideClick || !$open) return
+
+    const removeListener = on(window, 'pointerdown', (e) => {
+      if (contentEl && e.composedPath().includes(contentEl)) return
+
+      open.set(false)
+    })
+
+    return () => removeListener()
+  })
+
   $effect(() => {
     open.set(isOpened)
   })
@@ -70,6 +87,7 @@
 {#if $open}
   <div
     {...$content}
+    bind:this={contentEl}
     use:content
     out:flyAndScaleOutTransition
     class={cn(

--- a/src/stories/Design System - Core UI/Tooltip/TooltipWithButton.svelte
+++ b/src/stories/Design System - Core UI/Tooltip/TooltipWithButton.svelte
@@ -1,0 +1,35 @@
+<script>
+  import Button from '$ui/core/Button/Button.svelte'
+  import Tooltip from '$ui/core/Tooltip/Tooltip.svelte'
+</script>
+
+<main class="flex justify-center gap-4 py-40">
+  <Tooltip closeOnOutsideClick={false} position="bottom-start">
+    {#snippet children({ ref })}
+      <Button variant="border" {ref}>Open Tooltip</Button>
+    {/snippet}
+
+    {#snippet content()}
+      <section class="max-w-64">
+        Pass [closeOnOutsideClick={false}] to keep the tooltip open when clicking outside its
+        content.
+      </section>
+    {/snippet}
+  </Tooltip>
+
+  <Button variant="fill">Some Button</Button>
+
+  <Tooltip position="bottom-end">
+    {#snippet children({ ref })}
+      <Button variant="border" {ref}>Open Tooltip</Button>
+    {/snippet}
+
+    {#snippet content()}
+      <section class="max-w-64">
+        This tooltip’s content extends to the left and can sit behind the button next to it. If that
+        button opens a popover, the tooltip should close by default when clicking this button or
+        anywhere else outside the actual tooltip content.
+      </section>
+    {/snippet}
+  </Tooltip>
+</main>

--- a/src/stories/Design System - Core UI/Tooltip/TooltipWithButton.svelte
+++ b/src/stories/Design System - Core UI/Tooltip/TooltipWithButton.svelte
@@ -19,7 +19,7 @@
 
   <Button variant="fill">Some Button</Button>
 
-  <Tooltip position="bottom-end">
+  <Tooltip position="bottom-end" closeOnOutsideClick={true}>
     {#snippet children({ ref })}
       <Button variant="border" {ref}>Open Tooltip</Button>
     {/snippet}

--- a/src/stories/Design System - Core UI/Tooltip/index.stories.ts
+++ b/src/stories/Design System - Core UI/Tooltip/index.stories.ts
@@ -3,6 +3,7 @@ import type { Component, ComponentProps } from 'svelte'
 
 import component from './index.svelte'
 import PositionedTooltip from './PositionedTooltip.svelte'
+import TooltipWithButtonComponent from './TooltipWithButton.svelte'
 
 const meta = {
   component,
@@ -19,5 +20,11 @@ export const Tooltip: Story = {}
 export const TooltipWithPostitionConfig: StoryObj<typeof PositionedTooltip> = {
   render: () => ({
     Component: PositionedTooltip,
+  }),
+}
+
+export const TooltipWithButton: StoryObj<typeof TooltipWithButtonComponent> = {
+  render: () => ({
+    Component: TooltipWithButtonComponent,
   }),
 }


### PR DESCRIPTION
## Summary
Close Tooltip when clicking outside of its content. Add `closeOnOutsideClick` to control this behavior (`true` by default).

The Tooltip previously had an area above its content that prevented it from closing. When a Popover trigger was placed within this area, clicking it would open the Popover while leaving the Tooltip open. As a result, both components remained visible at the same time. It looks weird for regular buttons and links too.

By default, the Tooltip now closes whenever a `pointerdown` event occurs outside of its content.

The `melt-ui` library already provides a `closeOnPointerDown` prop, but it only handles `pointerdown` events on the trigger element itself.

## Notion card
https://www.notion.so/santiment/Notification-Centre-1st-iter-2b72a82d1361809e89bfedbbe8f51c6b?source=copy_link