### PR TITLE
fix(button) Fix type infered from tailwind-variants

### DIFF
--- a/package.json
+++ b/package.json
@@ -189,5 +189,10 @@
     "ua-parser-js": "1.0.39",
     "virtua": "0.41.5",
     "zod": "^3.23.8"
+  },
+  "pnpm": {
+    "patchedDependencies": {
+      "tailwind-variants@0.3.0": "patches/tailwind-variants@0.3.0.patch"
+    }
   }
 }

--- a/patches/tailwind-variants@0.3.0.patch
+++ b/patches/tailwind-variants@0.3.0.patch
@@ -1,0 +1,14 @@
+diff --git a/package.json b/package.json
+index 5d39c67..2c83279 100644
+--- a/package.json
++++ b/package.json
+@@ -87,6 +87,9 @@
+       "import": "./dist/index.js",
+       "types": "./dist/index.d.ts"
+     },
++    "./dist/config": {
++      "types": "./dist/config.d.ts"
++    },
+     "./dist/*": "./dist/*",
+     "./transformer": {
+       "require": "./dist/transformer.cjs",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: false
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  tailwind-variants@0.3.0:
+    hash: 277oyanjyyxcufsnp2uhvrjhjy
+    path: patches/tailwind-variants@0.3.0.patch
+
 dependencies:
   '@amplitude/analytics-browser':
     specifier: ^2.11.2
@@ -46,7 +51,7 @@ dependencies:
     version: 0.3.28(svelte@5.35.4)
   tailwind-variants:
     specifier: ^0.3.0
-    version: 0.3.0(tailwindcss@3.4.3)
+    version: 0.3.0(patch_hash=277oyanjyyxcufsnp2uhvrjhjy)(tailwindcss@3.4.3)
   tailwindcss-animate:
     specifier: ^1.0.7
     version: 1.0.7(tailwindcss@3.4.3)
@@ -10127,7 +10132,7 @@ packages:
   /tailwind-merge@2.5.4:
     resolution: {integrity: sha512-0q8cfZHMu9nuYP/b5Shb7Y7Sh1B7Nnl5GqNr1U+n2p6+mybvRtayrQ+0042Z5byvTA8ihjlP8Odo8/VnHbZu4Q==}
 
-  /tailwind-variants@0.3.0(tailwindcss@3.4.3):
+  /tailwind-variants@0.3.0(patch_hash=277oyanjyyxcufsnp2uhvrjhjy)(tailwindcss@3.4.3):
     resolution: {integrity: sha512-ho2k5kn+LB1fT5XdNS3Clb96zieWxbStE9wNLK7D0AV64kdZMaYzAKo0fWl6fXLPY99ffF9oBJnIj5escEl/8A==}
     engines: {node: '>=16.x', pnpm: '>=7.x'}
     peerDependencies:
@@ -10136,6 +10141,7 @@ packages:
       tailwind-merge: 2.5.4
       tailwindcss: 3.4.3
     dev: false
+    patched: true
 
   /tailwindcss-animate@1.0.7(tailwindcss@3.4.3):
     resolution: {integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==}


### PR DESCRIPTION
## Summary

- Notion ticket: https://www.notion.so/santiment/Fix-Button-has-any-type-for-variant-size-accent-props-3752a82d1361801d94f1ede358b64725?source=copy_link

Add patch for `tailwind-variants` to fix imports and types infered from button variants (`variant`, `size`, `accent`)
