### PR TITLE
chore(pricing) Update download as csv section info in breakdown table

### DIFF
--- a/src/lib/ui/app/SubscriptionPlan/BreakdownTable/breakdown.ts
+++ b/src/lib/ui/app/SubscriptionPlan/BreakdownTable/breakdown.ts
@@ -38,7 +38,7 @@ export const CONSUMER_PLANS_BREAKDOWN = [
         isAccess: true,
       },
       { name: 'Hide watermark on charts', isCheck: true },
-      { name: 'Download chart as CSV', isCheck: true },
+      { name: 'Download chart as CSV', isAccess: true },
       { name: 'Embed charts', isAccess: true },
     ],
   },
@@ -155,7 +155,7 @@ export const BUSINESS_PLANS_BREAKDOWN = [
         description: `<b>Limited data!</b> For users on the Free plan, some data has time range limitations`,
         isAccess: true,
       },
-      { name: 'Download chart data as CSV', isCheck: true },
+      { name: 'Download chart data as CSV', isAccess: true },
       { name: 'Embed charts', isAccess: true },
     ],
   },
@@ -254,6 +254,7 @@ export const SubscriptionPlanBreakdown: Record<
     'Custom onboarding & education': false,
 
     'Hide watermark on charts': false,
+    'Download chart as CSV': 'Limited to 2 years',
     'Embed charts': 'Part access',
 
     'Custom Alerts': 20,


### PR DESCRIPTION
## Summary

- Notion ticket: NO

Update download as csv section info in breakdown table:
- Sanbase PRO: Checkmark -> `Limited to 2 years`
- Sanbase MAX and all business: Checkmark -> `Full Access`
- `CSV` integration section is left intact

## Screenshots or videos

### BEFORE
<img width="1254" height="437" alt="image" src="https://github.com/user-attachments/assets/6668f6da-9279-4afd-8379-d8fd0cca0544" />

<img width="1185" height="435" alt="image" src="https://github.com/user-attachments/assets/533dda61-0c22-4432-a1b5-0775ac0e8a16" />


### AFTER
<img width="1189" height="401" alt="image" src="https://github.com/user-attachments/assets/9b708eb6-c5a9-49a5-9a4a-036e58054bf3" />

<img width="1184" height="365" alt="image" src="https://github.com/user-attachments/assets/4ab79ca3-33f2-49f1-97be-b1c948b06e05" />


