### PR TITLE
feat(account-status): make incomplete badge link to billing settings

### DIFF
--- a/.storybook/mock/user.ts
+++ b/.storybook/mock/user.ts
@@ -62,6 +62,9 @@ export type CurrentUser = null | {
     /** @default false */
     trial?: boolean
 
+    /** @default false */
+    incomplete?: boolean
+
     /** @default undefined */
     name?: string
 
@@ -110,6 +113,7 @@ export function mockUser(currentUser: CurrentUser) {
       monthly = false,
       yearly = false,
       trial = false,
+      incomplete = false,
       trialDaysLeft,
       cancelledInDays,
       name: planName,
@@ -157,7 +161,7 @@ export function mockUser(currentUser: CurrentUser) {
       const id = name && checkIsBusinessPlan(name) ? Product.SanAPI.id : Product.Sanbase.id
 
       subscriptions[0] = {
-        status: trial ? 'TRIALING' : 'ACTIVE',
+        status: incomplete ? 'INCOMPLETE' : trial ? 'TRIALING' : 'ACTIVE',
         trialEnd,
         cancelAtPeriodEnd: cancelledInDays !== undefined,
         currentPeriodEnd: currentPeriodEndDate.toISOString(),

--- a/src/lib/ui/app/AccountStatus/AccountStatus.svelte
+++ b/src/lib/ui/app/AccountStatus/AccountStatus.svelte
@@ -10,7 +10,7 @@
   {#if customer.$.plan}
     <div
       class={cn(
-        'rounded-md px-3 py-1.5 uppercase',
+        'relative rounded-md px-3 py-1.5 uppercase',
         customer.$.isBusinessSubscription
           ? 'bg-blue-light-1 text-blue'
           : 'bg-orange-light-1 text-orange',
@@ -18,7 +18,14 @@
     >
       {customer.$.planName}
       {#if customer.$.isIncompleteSubscription}
-        (Incomplete)
+        <a
+          href="/account#subscription"
+          class="link-as-bg"
+          data-type="update_billing"
+          data-source="account_status"
+        >
+          (Incomplete)
+        </a>
       {/if}
     </div>
   {:else}

--- a/src/stories/Design System - App UI/AccountStatus/index.stories.ts
+++ b/src/stories/Design System - App UI/AccountStatus/index.stories.ts
@@ -52,6 +52,17 @@ export const SanbasePro: Story = {
   },
 }
 
+export const SanbaseProIncomplete: Story = {
+  name: 'Sanbase Pro - Incomplete',
+  parameters: {
+    mockApi: () => ({
+      currentUser: {
+        plan: { pro: true, yearly: true, incomplete: true },
+      },
+    }),
+  },
+}
+
 export const ProPlus: Story = {
   name: 'Sanbase Pro+ (Deprecated)',
   parameters: {


### PR DESCRIPTION
### Description

Make the (Incomplete) badge a clickable link to /account#subscription so users can update their card

### Notion's task

https://app.notion.com/p/santiment/Added-Incomplete-state-for-AccountStatus-3892a82d136180f7adb5e1b242884771?source=copy_link

### Screenshots

<img width="290" height="83" alt="image" src="https://github.com/user-attachments/assets/b8be641d-c36a-496b-b072-144959d81dd4" />