### PR TITLE
feat/metric-info-extract

### DIFF
--- a/src/lib/ui/app/Chart/PaneLegend/Metric/InfoContent.svelte
+++ b/src/lib/ui/app/Chart/PaneLegend/Metric/InfoContent.svelte
@@ -4,8 +4,6 @@
   import { useAssetsCtx } from '$lib/ctx/assets/index.svelte.js'
   import Button from '$ui/core/Button/Button.svelte'
 
-  import { useChartGlobalParametersCtx } from '../../ctx/global-parameters.svelte.js'
-
   type TProps = {
     info: {
       description?: string
@@ -16,8 +14,9 @@
 
   const { info, metric }: TProps = $props()
 
-  const { globalParameters } = useChartGlobalParametersCtx.get()
   const { getAssetBySlug } = useAssetsCtx.get()
+
+  const metricSlug = $derived(metric?.type === 'asset_metric' ? metric.selector.$?.slug : undefined)
 
   const TICKER_REGEX = /\[Project Ticker\]/g
   export function replaceDescriptionMeta(description: string, ticker: string): string {
@@ -32,8 +31,7 @@
 
   <p>
     {#if info.description}
-      {@const slug = globalParameters.$$.selector.slug!}
-      {@const ticker = getAssetBySlug(slug)?.ticker || 'BTC'}
+      {@const ticker = (metricSlug && getAssetBySlug(metricSlug)?.ticker) ?? 'BTC'}
 
       {@html replaceDescriptionMeta(info.description, ticker)}
     {/if}

--- a/src/lib/ui/app/Chart/PaneLegend/Metric/InfoContent.svelte
+++ b/src/lib/ui/app/Chart/PaneLegend/Metric/InfoContent.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import type { TSeries } from '../../ctx/series.svelte.js'
+
+  import { useAssetsCtx } from '$lib/ctx/assets/index.svelte.js'
+  import Button from '$ui/core/Button/Button.svelte'
+
+  import { useChartGlobalParametersCtx } from '../../ctx/global-parameters.svelte.js'
+
+  type TProps = {
+    info: {
+      description?: string
+      academyLinks: string[]
+    } | null
+    metric: TSeries | null
+  }
+
+  const { info, metric }: TProps = $props()
+
+  const { globalParameters } = useChartGlobalParametersCtx.get()
+  const { getAssetBySlug } = useAssetsCtx.get()
+
+  const TICKER_REGEX = /\[Project Ticker\]/g
+  export function replaceDescriptionMeta(description: string, ticker: string): string {
+    return description.replace(TICKER_REGEX, ticker)
+  }
+</script>
+
+{#if info && metric}
+  <h3 class="mb-2.5 font-medium text-rhino">
+    {metric?.label}
+  </h3>
+
+  <p>
+    {#if info.description}
+      {@const slug = globalParameters.$$.selector.slug!}
+      {@const ticker = getAssetBySlug(slug)?.ticker || 'BTC'}
+
+      {@html replaceDescriptionMeta(info.description, ticker)}
+    {/if}
+
+    {#if info.academyLinks.length}
+      {#if info.description}
+        <br />
+      {/if}
+
+      Academy
+      <Button
+        variant="link"
+        target="_blank"
+        href="https://academy.santiment.net{info.academyLinks[0]}"
+        data-source="chart_pane_legend_metric_info"
+        data-type="metric_academy_article"
+      >
+        article
+      </Button>.
+    {/if}
+  </p>
+{:else}
+  No information available
+{/if}

--- a/src/lib/ui/app/Chart/PaneLegend/Metric/InfoContent.svelte
+++ b/src/lib/ui/app/Chart/PaneLegend/Metric/InfoContent.svelte
@@ -4,6 +4,8 @@
   import { useAssetsCtx } from '$lib/ctx/assets/index.svelte.js'
   import Button from '$ui/core/Button/Button.svelte'
 
+  import { useChartGlobalParametersCtx } from '../../ctx/global-parameters.svelte.js'
+
   type TProps = {
     info: {
       description?: string
@@ -14,9 +16,10 @@
 
   const { info, metric }: TProps = $props()
 
+  const { globalParameters } = useChartGlobalParametersCtx.get()
   const { getAssetBySlug } = useAssetsCtx.get()
 
-  const metricSlug = $derived(metric?.type === 'asset_metric' ? metric.selector.$?.slug : undefined)
+  const metricSlug = $derived(metric && 'selector' in metric ? metric.selector.$?.slug : undefined)
 
   const TICKER_REGEX = /\[Project Ticker\]/g
   export function replaceDescriptionMeta(description: string, ticker: string): string {
@@ -31,7 +34,8 @@
 
   <p>
     {#if info.description}
-      {@const ticker = (metricSlug && getAssetBySlug(metricSlug)?.ticker) ?? 'BTC'}
+      {@const slug = metricSlug ?? globalParameters.$$.selector.slug}
+      {@const ticker = (slug && getAssetBySlug(slug)?.ticker) ?? 'BTC'}
 
       {@html replaceDescriptionMeta(info.description, ticker)}
     {/if}

--- a/src/lib/ui/app/Chart/PaneLegend/Metric/InfoPopover.svelte
+++ b/src/lib/ui/app/Chart/PaneLegend/Metric/InfoPopover.svelte
@@ -6,18 +6,15 @@
     useMetricsRestrictionsCtx,
     type TMetricRestrictions,
   } from '$lib/ctx/metrics-registry/index.js'
-  import Button from '$ui/core/Button/index.js'
-  import { useAssetsCtx } from '$lib/ctx/assets/index.svelte.js'
 
-  import { useChartGlobalParametersCtx, type TSeries } from '../../ctx/index.js'
+  import { type TSeries } from '../../ctx/index.js'
   import { useMetricInfoCtx } from './ctx.svelte.js'
+  import InfoContent from './InfoContent.svelte'
 
   type TProps = { children: Snippet }
   let { children }: TProps = $props()
 
   const { MetricsRestrictions } = useMetricsRestrictionsCtx.get()
-  const { globalParameters } = useChartGlobalParametersCtx.get()
-  const { getAssetBySlug } = useAssetsCtx.get()
 
   let openedMetric = $state.raw<null | TSeries>(null)
   let openedInfo = $state.raw<null | TMetricRestrictions['docs']>(null)
@@ -48,11 +45,6 @@
       openedMetric = anchorNode = openedInfo = null
     }, 200)
   }
-
-  const TICKER_REGEX = /\[Project Ticker\]/g
-  export function replaceDescriptionMeta(description: string, ticker: string): string {
-    return description.replace(TICKER_REGEX, ticker)
-  }
 </script>
 
 {@render children()}
@@ -68,38 +60,6 @@
   class="w-[360px] px-6 py-5 pt-4 text-rhino column"
 >
   {#snippet content()}
-    {#if openedInfo && openedMetric}
-      <h3 class="mb-2.5 font-medium text-rhino">
-        {openedMetric?.label}
-      </h3>
-
-      <p>
-        {#if openedInfo.description}
-          {@const slug = globalParameters.$$.selector.slug!}
-          {@const ticker = getAssetBySlug(slug)?.ticker || 'BTC'}
-
-          {@html replaceDescriptionMeta(openedInfo.description, ticker)}
-        {/if}
-
-        {#if openedInfo.academyLinks.length}
-          {#if openedInfo.description}
-            <br />
-          {/if}
-
-          Academy
-          <Button
-            variant="link"
-            target="_blank"
-            href="https://academy.santiment.net{openedInfo.academyLinks[0]}"
-            data-source="chart_pane_legend_metric_info"
-            data-type="metric_academy_article"
-          >
-            article
-          </Button>.
-        {/if}
-      </p>
-    {:else}
-      No information available
-    {/if}
+    <InfoContent metric={openedMetric} info={openedInfo} />
   {/snippet}
 </Popover>

--- a/src/lib/ui/app/Chart/PaneLegend/index.ts
+++ b/src/lib/ui/app/Chart/PaneLegend/index.ts
@@ -4,6 +4,7 @@ export { default as PaneMetricValue } from './Metric/Value.svelte'
 export { default as PaneMetricGranularityStatus } from './Metric/GranularityStatus.svelte'
 export { default as PaneMetricVersionStatus } from './Metric/VersionStatus.svelte'
 export { default as PaneMetricSettingsSchemaStatus } from './Metric/SettingsSchemaStatus.svelte'
+export { default as PaneMetricInfoContent } from './Metric/InfoContent.svelte'
 export { default as AIExplanationStatus } from './Metric/AIExplanationStatus.svelte'
 
 export { usePaneLegendCompactCtx } from './ctx.svelte.js'


### PR DESCRIPTION
## Summary

- Notion ticket: https://app.notion.com/p/santiment/Mobile-charts-design-update-3902a82d1361800cacc9c855af7ebb42?source=copy_link

1. Extract `PaneMetricInfoContent` component
2. Fix metric info description: global slug selector was used instead of metric slug

## Screenshots or videos
<img width="727" height="224" alt="Screenshot 2026-07-06 at 09 37 16" src="https://github.com/user-attachments/assets/ecde33b7-c2dc-4ebb-8206-2aeeb350f671" />

