### PR TITLE
fix(scripts) Fix build and release scripts --run check

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -1,5 +1,6 @@
 import fs from 'fs'
 import path from 'path'
+import url from 'url'
 
 import { exec, forFile } from './utils.js'
 import { fetchStatusAssetLogos, replaceAssetLogosSource } from './asset-logos.js'
@@ -21,7 +22,7 @@ export async function build() {
   await replaceSrcImports()
 }
 
-if (process.argv[2] === '--run') build()
+if (process.argv[2] === '--run' && process.argv[1] === url.fileURLToPath(import.meta.url)) build()
 
 async function updateLibraryPackageJson() {
   const exports = {}

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import url from 'url'
 
 import { processFormulasModules } from './san-formulas-check.js'
 import { exec } from './utils.js'
@@ -83,7 +84,7 @@ vite.config.ts
   await exec(`npm run prepare`, false)
 }
 
-if (process.argv[2] === '--run') release()
+if (process.argv[2] === '--run' && process.argv[1] === url.fileURLToPath(import.meta.url)) release()
 
 async function getReleaseTag() {
   let [gitHash] = await exec('git rev-parse --short HEAD', false)


### PR DESCRIPTION
## Summary

- Notion ticket:

Fix `build` and `release` scripts' `--run` check. The bug leaded to `build` ran twice on `lib:release`