### PR TITLE
feat/enhance-search-logic

### DIFF
--- a/src/lib/ctx/search/index.svelte.ts
+++ b/src/lib/ctx/search/index.svelte.ts
@@ -9,14 +9,16 @@ type TSearchProps<T> = {
 export const useSearchCtx = createCtx(
   'webkit_useSearchCtx',
   <GItem>({ getCompareValues }: TSearchProps<GItem>) => {
-    let searchTerm = $state('')
+    let searchTerm = $state.raw<string[]>([])
+
+    const isSearching = $derived(searchTerm.length > 0)
 
     const onSearch = useDebouncedFn(250, (value: string) => {
-      searchTerm = value
+      searchTerm = value ? value.split(' ') : []
     })
 
     const onInput: ChangeEventHandler<HTMLInputElement> = ({ currentTarget }) =>
-      onSearch(currentTarget.value)
+      onSearch(currentTarget.value.trim().toLowerCase())
 
     const match = (value: string, target: string) => target.toLowerCase().includes(value)
 
@@ -28,19 +30,18 @@ export const useSearchCtx = createCtx(
         : match(value, compareValues)
     }
 
-    const filter = <T extends GItem>(items: T[]) => {
-      const value = searchTerm.toLocaleLowerCase()
-      if (!value) return items
-
-      return items.filter((item) => matchItem(value, item))
-    }
+    const filter = <T extends GItem>(items: T[]) =>
+      isSearching
+        ? items.filter((item) => searchTerm.every((value) => matchItem(value, item)))
+        : items
 
     const onKeyUp: KeyboardEventHandler<HTMLInputElement> = ({ currentTarget, code }) => {
       if (!currentTarget) return
 
       if (code === 'Escape') {
         if (searchTerm) {
-          currentTarget.value = searchTerm = ''
+          searchTerm = []
+          currentTarget.value = ''
         }
       }
     }
@@ -51,11 +52,16 @@ export const useSearchCtx = createCtx(
           return searchTerm
         },
       },
+      isSearching: {
+        get $() {
+          return isSearching
+        },
+      },
       filter,
       onKeyUp,
       onInput,
       clear() {
-        searchTerm = ''
+        searchTerm = []
       },
     }
   },

--- a/src/stories/Design System - Core UI/Search/index.stories.ts
+++ b/src/stories/Design System - Core UI/Search/index.stories.ts
@@ -1,0 +1,15 @@
+import type { Meta, StoryObj } from '@storybook/svelte'
+
+import component from './index.svelte'
+
+const meta = {
+  component,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<component>
+type Story = StoryObj<typeof meta>
+
+export default meta
+
+export const Assets: Story = {}

--- a/src/stories/Design System - Core UI/Search/index.svelte
+++ b/src/stories/Design System - Core UI/Search/index.svelte
@@ -1,0 +1,31 @@
+<script lang="ts">
+  import type { TAsset } from '$lib/ctx/assets/api.js'
+  import { useAssetsCtx } from '$lib/ctx/assets/index.svelte.js'
+  import { useSearchCtx } from '$lib/ctx/search/index.svelte.js'
+  import AssetLogo from '$ui/app/AssetLogo/AssetLogo.svelte'
+  import VirtualList from '$ui/app/VirtualList/VirtualList.svelte'
+  import Input from '$ui/core/Input/Input.svelte'
+
+  const { assets } = useAssetsCtx()
+
+  const { filter, onInput, onKeyUp } = useSearchCtx<TAsset>({
+    getCompareValues: ({ slug, ticker, name }) => [slug, ticker, name],
+  })
+
+  const filtered = $derived(filter(assets.$))
+</script>
+
+<main class="flex h-96 flex-col p-5">
+  <Input icon="search" placeholder="Search for asset" oninput={onInput} onkeyup={onKeyUp} />
+
+  <section class="flex-1">
+    <VirtualList data={filtered} itemHeight={40} getKey={(item) => item.slug} class="p-6">
+      {#snippet children({ slug, ticker, name }, i)}
+        <article class="flex gap-2">
+          <AssetLogo {slug} />
+          <span>{name} ({ticker})</span>
+        </article>
+      {/snippet}
+    </VirtualList>
+  </section>
+</main>


### PR DESCRIPTION
## Summary

- Notion ticket: https://app.notion.com/p/santiment/Mobile-charts-design-update-3902a82d1361800cacc9c855af7ebb42?source=copy_link

Enhance logic of `useSearchCtx`. Copy Sanbase's `AddAssetMetricDialog` asset searching and generalize it here.

Changes:
1. Split `searchTerm` by space and use each part individually. Every part must match for item to fit the search
2. Add `isSearching` helper prop

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #450 
- <kbd>&nbsp;1&nbsp;</kbd> #449 👈 
<!-- GitButler Footer Boundary Bottom -->

