### PR TITLE
refactor/search

### DIFF
--- a/src/lib/ctx/search/index.svelte.ts
+++ b/src/lib/ctx/search/index.svelte.ts
@@ -17,7 +17,7 @@ export const useSearchCtx = createCtx(
       searchTerm = value ? value.split(' ') : []
     })
 
-    const onInput: ChangeEventHandler<HTMLInputElement> = ({ currentTarget }) =>
+    const oninput: ChangeEventHandler<HTMLInputElement> = ({ currentTarget }) =>
       onSearch(currentTarget.value.trim().toLowerCase())
 
     const match = (value: string, target: string) => target.toLowerCase().includes(value)
@@ -35,7 +35,7 @@ export const useSearchCtx = createCtx(
         ? items.filter((item) => searchTerm.every((value) => matchItem(value, item)))
         : items
 
-    const onKeyUp: KeyboardEventHandler<HTMLInputElement> = ({ currentTarget, code }) => {
+    const onkeyup: KeyboardEventHandler<HTMLInputElement> = ({ currentTarget, code }) => {
       if (!currentTarget) return
 
       if (code === 'Escape') {
@@ -58,8 +58,12 @@ export const useSearchCtx = createCtx(
         },
       },
       filter,
-      onKeyUp,
-      onInput,
+      /** @deprecated use [onkeyup] instead */
+      onKeyUp: onkeyup,
+      /** @deprecated use [oninput] instead */
+      onInput: oninput,
+      onkeyup,
+      oninput,
       clear() {
         searchTerm = []
       },

--- a/src/lib/ctx/search/index.svelte.ts
+++ b/src/lib/ctx/search/index.svelte.ts
@@ -6,67 +6,67 @@ type TSearchProps<T> = {
   getCompareValues: (item: T) => string | string[]
 }
 
-export const useSearchCtx = createCtx(
-  'webkit_useSearchCtx',
-  <GItem>({ getCompareValues }: TSearchProps<GItem>) => {
-    let searchTerm = $state.raw<string[]>([])
+export const useSearchFlow = <GItem>({ getCompareValues }: TSearchProps<GItem>) => {
+  let searchTerm = $state.raw<string[]>([])
 
-    const isSearching = $derived(searchTerm.length > 0)
+  const isSearching = $derived(searchTerm.length > 0)
 
-    const onSearch = useDebouncedFn(250, (value: string) => {
-      searchTerm = value ? value.split(' ') : []
-    })
+  const onSearch = useDebouncedFn(250, (value: string) => {
+    searchTerm = value ? value.split(' ') : []
+  })
 
-    const oninput: ChangeEventHandler<HTMLInputElement> = ({ currentTarget }) =>
-      onSearch(currentTarget.value.trim().toLowerCase())
+  const oninput: ChangeEventHandler<HTMLInputElement> = ({ currentTarget }) =>
+    onSearch(currentTarget.value.trim().toLowerCase())
 
-    const match = (value: string, target: string) => target.toLowerCase().includes(value)
+  const match = (value: string, target: string) => target.toLowerCase().includes(value)
 
-    const matchItem = (value: string, item: GItem) => {
-      const compareValues = getCompareValues(item)
+  const matchItem = (value: string, item: GItem) => {
+    const compareValues = getCompareValues(item)
 
-      return Array.isArray(compareValues)
-        ? compareValues.some((target) => match(value, target))
-        : match(value, compareValues)
-    }
+    return Array.isArray(compareValues)
+      ? compareValues.some((target) => match(value, target))
+      : match(value, compareValues)
+  }
 
-    const filter = <T extends GItem>(items: T[]) =>
-      isSearching
-        ? items.filter((item) => searchTerm.every((value) => matchItem(value, item)))
-        : items
+  const filter = <T extends GItem>(items: T[]) =>
+    isSearching
+      ? items.filter((item) => searchTerm.every((value) => matchItem(value, item)))
+      : items
 
-    const onkeyup: KeyboardEventHandler<HTMLInputElement> = ({ currentTarget, code }) => {
-      if (!currentTarget) return
+  const onkeyup: KeyboardEventHandler<HTMLInputElement> = ({ currentTarget, code }) => {
+    if (!currentTarget) return
 
-      if (code === 'Escape') {
-        if (searchTerm) {
-          searchTerm = []
-          currentTarget.value = ''
-        }
+    if (code === 'Escape') {
+      if (searchTerm) {
+        searchTerm = []
+        currentTarget.value = ''
       }
     }
+  }
 
-    return {
-      searchTerm: {
-        get $() {
-          return searchTerm
-        },
+  return {
+    searchTerm: {
+      get $() {
+        return searchTerm
       },
-      isSearching: {
-        get $() {
-          return isSearching
-        },
+    },
+    isSearching: {
+      get $() {
+        return isSearching
       },
-      filter,
-      /** @deprecated use [onkeyup] instead */
-      onKeyUp: onkeyup,
-      /** @deprecated use [oninput] instead */
-      onInput: oninput,
-      onkeyup,
-      oninput,
-      clear() {
-        searchTerm = []
-      },
-    }
-  },
-)
+    },
+    filter,
+    /** @deprecated use [onkeyup] instead */
+    onKeyUp: onkeyup,
+    /** @deprecated use [oninput] instead */
+    onInput: oninput,
+    onkeyup,
+    oninput,
+    clear() {
+      searchTerm = []
+    },
+  }
+}
+
+/** @deprecated use [useSearchFlow] instead */
+export const useSearchCtx = createCtx('webkit_useSearchCtx', useSearchFlow)

--- a/src/lib/ctx/search/index.ts
+++ b/src/lib/ctx/search/index.ts
@@ -1,1 +1,1 @@
-export { useSearchCtx } from './index.svelte.js'
+export { useSearchCtx, useSearchFlow } from './index.svelte.js'

--- a/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/ui/Word.svelte
+++ b/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/ui/Word.svelte
@@ -33,7 +33,7 @@
 
   const { stepState }: TProps = $props()
 
-  const { filter, onInput, onKeyUp, clear } = useSearchCtx<Item>({
+  const { filter, oninput, onkeyup, clear } = useSearchCtx<Item>({
     getCompareValues: ({ value }) => value,
   })
 
@@ -84,12 +84,7 @@
 </script>
 
 <section class="flex flex-1 flex-col gap-3">
-  <Input
-    icon="search"
-    placeholder="Search for trending words"
-    oninput={onInput}
-    onkeyup={onKeyUp}
-  />
+  <Input icon="search" placeholder="Search for trending words" {oninput} {onkeyup} />
 
   <section class="flex-1">
     <VirtualList itemHeight={36} data={allItems} getKey={({ key }) => key}>

--- a/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/ui/Word.svelte
+++ b/src/lib/ui/app/Alerts/categories/social-trends/select-trend-form-step/ui/Word.svelte
@@ -10,7 +10,7 @@
   import Checkbox from '$ui/core/Checkbox/Checkbox.svelte'
   import Button from '$ui/core/Button/Button.svelte'
   import Input from '$ui/core/Input/Input.svelte'
-  import { useSearchCtx } from '$lib/ctx/search/index.svelte.js'
+  import { useSearchFlow } from '$lib/ctx/search/index.svelte.js'
 
   import { queryTrendingWords } from './api.js'
 
@@ -33,7 +33,7 @@
 
   const { stepState }: TProps = $props()
 
-  const { filter, oninput, onkeyup, clear } = useSearchCtx<Item>({
+  const { filter, oninput, onkeyup, clear } = useSearchFlow<Item>({
     getCompareValues: ({ value }) => value,
   })
 

--- a/src/lib/ui/app/Alerts/categories/wallet/wallet-form-step/ui/SelectAsset.svelte
+++ b/src/lib/ui/app/Alerts/categories/wallet/wallet-form-step/ui/SelectAsset.svelte
@@ -2,7 +2,7 @@
   import { onMount } from 'svelte'
 
   import { useAssetsCtx } from '$lib/ctx/assets/index.svelte.js'
-  import { useSearchCtx } from '$lib/ctx/search/index.svelte.js'
+  import { useSearchFlow } from '$lib/ctx/search/index.svelte.js'
   import Popover from '$ui/core/Popover/Popover.svelte'
   import Input from '$ui/core/Input/Input.svelte'
   import VirtualList from '$ui/app/VirtualList/VirtualList.svelte'
@@ -17,7 +17,7 @@
   const { selected, slugs, onSelect }: TProps = $props()
 
   const { getAssetBySlug } = useAssetsCtx()
-  const { filter, clear, oninput, onkeyup } = useSearchCtx<string>({
+  const { filter, clear, oninput, onkeyup } = useSearchFlow<string>({
     getCompareValues: (slug) => {
       const asset = getAssetBySlug(slug)
       if (!asset) return slug

--- a/src/lib/ui/app/Alerts/categories/wallet/wallet-form-step/ui/SelectAsset.svelte
+++ b/src/lib/ui/app/Alerts/categories/wallet/wallet-form-step/ui/SelectAsset.svelte
@@ -17,7 +17,7 @@
   const { selected, slugs, onSelect }: TProps = $props()
 
   const { getAssetBySlug } = useAssetsCtx()
-  const { filter, clear, onInput, onKeyUp } = useSearchCtx<string>({
+  const { filter, clear, oninput, onkeyup } = useSearchCtx<string>({
     getCompareValues: (slug) => {
       const asset = getAssetBySlug(slug)
       if (!asset) return slug
@@ -54,13 +54,7 @@
 
   {#snippet content({ close })}
     <section class="flex flex-col gap-2">
-      <Input
-        icon="search"
-        oninput={onInput}
-        onkeyup={onKeyUp}
-        placeholder="Search assets"
-        autofocus
-      />
+      <Input icon="search" {oninput} {onkeyup} placeholder="Search assets" autofocus />
 
       <section class="flex-1">
         <VirtualList itemHeight={30} maxHeight={335} data={filtered} getKey={(slug) => slug}>

--- a/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/ui/ListOfWatchlists.svelte
+++ b/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/ui/ListOfWatchlists.svelte
@@ -22,7 +22,7 @@
   const { watchlists, checkWatchlistHasAnotherAlert } = useUserWatchlistsCtx({ loadScreeners })
   const { initialAlert } = useAlertFormCtx.get()
 
-  const { filter, clear, onInput, onKeyUp } = useSearchCtx<Watchlist>({
+  const { filter, clear, oninput, onkeyup } = useSearchCtx<Watchlist>({
     getCompareValues: ({ title, description }) => [title, description ?? ''],
   })
 
@@ -43,7 +43,7 @@
 </script>
 
 <section class="flex flex-col gap-3">
-  <Input icon="search" placeholder="Search for watchlist" oninput={onInput} onkeyup={onKeyUp} />
+  <Input icon="search" placeholder="Search for watchlist" {oninput} {onkeyup} />
 
   <section class="flex flex-col gap-3">
     {#each filteredWatchlists as watchlist}

--- a/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/ui/ListOfWatchlists.svelte
+++ b/src/lib/ui/app/Alerts/categories/watchlist/watchlist-form-step/ui/ListOfWatchlists.svelte
@@ -4,7 +4,7 @@
   import Button from '$ui/core/Button/Button.svelte'
   import { cn } from '$ui/utils/index.js'
   import Svg from '$ui/core/Svg/Svg.svelte'
-  import { useSearchCtx } from '$lib/ctx/search/index.svelte.js'
+  import { useSearchFlow } from '$lib/ctx/search/index.svelte.js'
   import Input from '$ui/core/Input/Input.svelte'
   import { useAlertFormCtx } from '$ui/app/Alerts/ctx/index.svelte.js'
 
@@ -22,7 +22,7 @@
   const { watchlists, checkWatchlistHasAnotherAlert } = useUserWatchlistsCtx({ loadScreeners })
   const { initialAlert } = useAlertFormCtx.get()
 
-  const { filter, clear, oninput, onkeyup } = useSearchCtx<Watchlist>({
+  const { filter, clear, oninput, onkeyup } = useSearchFlow<Watchlist>({
     getCompareValues: ({ title, description }) => [title, description ?? ''],
   })
 

--- a/src/lib/ui/app/Alerts/form-steps/metric-conditions/ui/metrics.svelte.ts
+++ b/src/lib/ui/app/Alerts/form-steps/metric-conditions/ui/metrics.svelte.ts
@@ -15,7 +15,7 @@ export const useMetricGraph = () => {
   const { steps } = useAlertFormCtx.get()
 
   const { MetricsRegistry } = useMetricsRegistryCtx()
-  const { filter, searchTerm, onInput, onKeyUp } = useSearchCtx<TRegistryMetric>({
+  const { filter, searchTerm, oninput, onkeyup } = useSearchCtx<TRegistryMetric>({
     getCompareValues: ({ label }) => [label],
   })
 
@@ -33,8 +33,8 @@ export const useMetricGraph = () => {
   const metricGraph = $derived(getMetricsCategoryGroupGraph(filteredMetrics))
 
   return {
-    onSearchInput: onInput,
-    onSearchKeyUp: onKeyUp,
+    onSearchInput: oninput,
+    onSearchKeyUp: onkeyup,
     searchTerm,
     graph: {
       get $() {

--- a/src/lib/ui/app/Alerts/form-steps/metric-conditions/ui/metrics.svelte.ts
+++ b/src/lib/ui/app/Alerts/form-steps/metric-conditions/ui/metrics.svelte.ts
@@ -5,7 +5,7 @@ import {
   type TMetricsRegistry,
   type TRegistryMetric,
 } from '$lib/ctx/metrics-registry/index.js'
-import { useSearchCtx } from '$lib/ctx/search/index.svelte.js'
+import { useSearchFlow } from '$lib/ctx/search/index.svelte.js'
 import { useAlertFormCtx, type TAnyStep } from '$ui/app/Alerts/ctx/index.svelte.js'
 
 import { queryAvailableMetrics } from '../api.js'
@@ -15,7 +15,7 @@ export const useMetricGraph = () => {
   const { steps } = useAlertFormCtx.get()
 
   const { MetricsRegistry } = useMetricsRegistryCtx()
-  const { filter, searchTerm, oninput, onkeyup } = useSearchCtx<TRegistryMetric>({
+  const { filter, searchTerm, oninput, onkeyup } = useSearchFlow<TRegistryMetric>({
     getCompareValues: ({ label }) => [label],
   })
 

--- a/src/lib/ui/app/ListOfAssets/Layout.svelte
+++ b/src/lib/ui/app/ListOfAssets/Layout.svelte
@@ -5,7 +5,7 @@
   import { map, noop, pipe, switchMap, tap } from 'rxjs'
 
   import Input from '$ui/core/Input/Input.svelte'
-  import { useSearchCtx } from '$lib/ctx/search/index.js'
+  import { useSearchFlow } from '$lib/ctx/search/index.js'
   import { useObserveFnCall } from '$lib/utils/observable.svelte.js'
   import { cn } from '$ui/utils/index.js'
 
@@ -31,7 +31,7 @@
     children,
   }: TProps = $props()
 
-  const { filter, oninput, onkeyup, clear } = useSearchCtx<TAsset>({
+  const { filter, onKeyUp, oninput, onkeyup, clear } = useSearchFlow<TAsset>({
     getCompareValues: ({ slug, ticker, name }) => [slug, ticker, name],
   })
 

--- a/src/lib/ui/app/ListOfAssets/Layout.svelte
+++ b/src/lib/ui/app/ListOfAssets/Layout.svelte
@@ -31,7 +31,7 @@
     children,
   }: TProps = $props()
 
-  const { filter, onInput, onKeyUp, clear } = useSearchCtx<TAsset>({
+  const { filter, oninput, onkeyup, clear } = useSearchCtx<TAsset>({
     getCompareValues: ({ slug, ticker, name }) => [slug, ticker, name],
   })
 
@@ -75,8 +75,8 @@
         inputClass="md:py-2.5"
         icon="search"
         placeholder="Search project"
-        oninput={onInput}
-        onkeyup={onKeyUp}
+        {oninput}
+        {onkeyup}
       />
     {/if}
 

--- a/src/stories/Design System - Core UI/Search/index.svelte
+++ b/src/stories/Design System - Core UI/Search/index.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
   import type { TAsset } from '$lib/ctx/assets/api.js'
   import { useAssetsCtx } from '$lib/ctx/assets/index.svelte.js'
-  import { useSearchCtx } from '$lib/ctx/search/index.svelte.js'
+  import { useSearchFlow } from '$lib/ctx/search/index.svelte.js'
   import AssetLogo from '$ui/app/AssetLogo/AssetLogo.svelte'
   import VirtualList from '$ui/app/VirtualList/VirtualList.svelte'
   import Input from '$ui/core/Input/Input.svelte'
 
   const { assets } = useAssetsCtx()
 
-  const { filter, oninput, onkeyup } = useSearchCtx<TAsset>({
+  const { filter, oninput, onkeyup } = useSearchFlow<TAsset>({
     getCompareValues: ({ slug, ticker, name }) => [slug, ticker, name],
   })
 

--- a/src/stories/Design System - Core UI/Search/index.svelte
+++ b/src/stories/Design System - Core UI/Search/index.svelte
@@ -8,7 +8,7 @@
 
   const { assets } = useAssetsCtx()
 
-  const { filter, onInput, onKeyUp } = useSearchCtx<TAsset>({
+  const { filter, oninput, onkeyup } = useSearchCtx<TAsset>({
     getCompareValues: ({ slug, ticker, name }) => [slug, ticker, name],
   })
 
@@ -16,7 +16,7 @@
 </script>
 
 <main class="flex h-96 flex-col p-5">
-  <Input icon="search" placeholder="Search for asset" oninput={onInput} onkeyup={onKeyUp} />
+  <Input icon="search" placeholder="Search for asset" {oninput} {onkeyup} />
 
   <section class="flex-1">
     <VirtualList data={filtered} itemHeight={40} getKey={(item) => item.slug} class="p-6">


### PR DESCRIPTION
## Summary

- Notion ticket: https://app.notion.com/p/santiment/Mobile-charts-design-update-3902a82d1361800cacc9c855af7ebb42?source=copy_link

1. Return `oninput` and `onkeyup` instead of `onInput` and `onKeyUp` from `useSearchCtx` to use these helpers as shorthand props in input-like elements 
2. Rename `useSearchCtx` to `useSearchFlow` and remove ctx creation for it since ctx is not needed here semantically. `useSearchCtx` is left for backward compatibility but marked as `@deprecated`

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #450 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #449 
<!-- GitButler Footer Boundary Bottom -->

