### PR TITLE
fix/ipad-download

### DIFF
--- a/src/lib/ui/app/Chart/screenshot.ts
+++ b/src/lib/ui/app/Chart/screenshot.ts
@@ -155,13 +155,30 @@ export async function downloadChartAsJpeg(title: string, metrics: TSeries[], cha
 
   drawMetricsOnCanvas(ctx, chart, metrics)
 
-  const url = finalCanvas.toDataURL('image/jpeg', 0.9)
-  const now = new Date()
-  const { DD, MMM, YYYY } = getDateFormats(now)
-  const { HH, mm, ss } = getTimeFormats(now)
+  finalCanvas.toBlob(
+    (blob) => {
+      if (!blob) {
+        console.error('Failed to create blob from canvas')
+        return
+      }
 
-  const a = document.createElement('a')
-  a.href = url
-  a.download = `${title} [${HH}.${mm}.${ss}, ${DD} ${MMM}, ${YYYY}].jpeg`
-  a.click()
+      const now = new Date()
+      const { DD, MMM, YYYY } = getDateFormats(now)
+      const { HH, mm, ss } = getTimeFormats(now)
+
+      const url = URL.createObjectURL(blob)
+
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `${title} [${HH}.${mm}.${ss}, ${DD} ${MMM}, ${YYYY}].jpeg`
+      a.click()
+      a.remove()
+
+      setTimeout(() => {
+        URL.revokeObjectURL(url)
+      }, 30_000)
+    },
+    'image/jpeg',
+    0.9,
+  )
 }

--- a/src/lib/utils/csv/index.ts
+++ b/src/lib/utils/csv/index.ts
@@ -44,7 +44,10 @@ export function downloadCsv<T>(title: string, headers: Header<T>[], data: T[]) {
   a.href = url
   a.click()
   a.remove()
-  URL.revokeObjectURL(url)
+
+  setTimeout(() => {
+    URL.revokeObjectURL(url)
+  }, 30_000)
 }
 
 export function createMetricSeriesCsvHeaders(series: TSeries[]) {

--- a/src/lib/utils/csv/index.ts
+++ b/src/lib/utils/csv/index.ts
@@ -22,17 +22,29 @@ export function downloadCsv<T>(title: string, headers: Header<T>[], data: T[]) {
     ),
   ]
 
-  const csvContent = 'data:text/csv;charset=utf-8,' + rows.map((e) => e.join(',')).join('\n')
+  const csvContent = rows.map((e) => e.join(',')).join('\n')
 
   const date = new Date()
   const { DD, MMM, YYYY } = getDateFormats(date)
   const { HH, mm, ss } = getTimeFormats(date)
 
+  const blob = new Blob(
+    [
+      //NOTE: This UTF‑8 BOM is needed for Excel to open the csv as UTF-8
+      '\uFEFF',
+      csvContent,
+    ],
+    { type: 'text/csv;charset=utf-8' },
+  )
+
   const a = document.createElement('a')
+  const url = URL.createObjectURL(blob)
+
   a.download = `${title} [${HH}.${mm}.${ss}, ${DD} ${MMM}, ${YYYY}].csv`
-  a.href = encodeURI(csvContent)
+  a.href = url
   a.click()
   a.remove()
+  URL.revokeObjectURL(url)
 }
 
 export function createMetricSeriesCsvHeaders(series: TSeries[]) {


### PR DESCRIPTION
## Summary

- Notion ticket: https://app.notion.com/p/santiment/Fix-csv-jpeg-download-on-IPadOS-26-5-2-3a52a82d1361801b8b18e5237c9a5de7?source=copy_link

The reason of issue was most probably download with data url regression in WebKit in iPadOS 26+

Changes:
1. Download with data url was replaced with blob for both csv and jped download
2. Revoke data url only after 30 seconds

NOTE: For now there is no need to timeout revoke url. It works without timeout now, but since mobile safari has confirmation dialog, I think it's more safe to have timeout for browser to have time to capture downloading object

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #453 
- <kbd>&nbsp;1&nbsp;</kbd> #452 👈 
<!-- GitButler Footer Boundary Bottom -->

