### PR TITLE
fix(dialog): mobile dialog landscape view goes out the screen

### DIFF
--- a/src/lib/ui/core/Dialog/Responsive/MobileLandscapeModal.svelte
+++ b/src/lib/ui/core/Dialog/Responsive/MobileLandscapeModal.svelte
@@ -49,7 +49,7 @@
     <div
       class={cn(
         'fixed inset-0 z-50 overflow-hidden bg-white',
-        !isLandscape && 'top-full h-[100vw] w-[100vh] origin-top-left -rotate-90',
+        !isLandscape && 'top-full h-[100dvw] w-[100dvh] origin-top-left -rotate-90',
         className,
       )}
       transition:flyAndScale


### PR DESCRIPTION
### Description

1. Fixed Mobile Landscape Overview

<img width="370" height="632" alt="image" src="https://github.com/user-attachments/assets/be06b6a8-016a-4c5b-93b1-4e89ba362066" />


### Notion's task

https://app.notion.com/p/santiment/Social-Trends-Mobile-Addons-3aa2a82d136180a685ebd60dc75beb5f?source=copy_link