### PR TITLE
feat(popover) Add openOnHover prop to Popover

### DIFF
--- a/src/lib/ui/core/Popover/Popover.svelte
+++ b/src/lib/ui/core/Popover/Popover.svelte
@@ -26,6 +26,10 @@
     contentProps?: PopoverContentProps
 
     portalTo?: ComponentProps<typeof Popover.Portal>['to']
+
+    openDelay?: number
+    closeDelay?: number
+    openOnHover?: boolean
   }
 
   let {
@@ -34,7 +38,11 @@
     children,
     noStyles = false,
     matchTriggerWidth = false,
+    openOnHover = false,
     isOpened = $bindable(false),
+
+    openDelay = 0,
+    closeDelay = 0,
 
     portalTo,
 
@@ -49,7 +57,7 @@
 </script>
 
 <Popover.Root {...rootProps} bind:open={isOpened}>
-  <Popover.Trigger child={children}></Popover.Trigger>
+  <Popover.Trigger child={children} {openDelay} {closeDelay} {openOnHover} />
 
   <Popover.Portal disabled={!portalTo} to={portalTo}>
     <Popover.Content


### PR DESCRIPTION
## Summary

- Notion ticket: https://app.notion.com/p/santiment/Fix-bugs-on-tablets-July-2026-3a72a82d13618092b124d2f2efb6b0d2?source=copy_link

Add `openOnHover`, `openDelay` and `closeDelay` props to `Popover` to allow opening on hover

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #460 
- <kbd>&nbsp;3&nbsp;</kbd> #459 
- <kbd>&nbsp;2&nbsp;</kbd> #458 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #457 
<!-- GitButler Footer Boundary Bottom -->