### PR TITLE
fix(popover) Use popover instead of tooltip for menus

### DIFF
--- a/src/lib/ui/app/AccountDropdown/AccountDropdown.svelte
+++ b/src/lib/ui/app/AccountDropdown/AccountDropdown.svelte
@@ -6,10 +6,10 @@
   import { useUiCtx, useCustomerNightModeToggleFlow } from '$lib/ctx/ui/index.js'
   import Button from '$ui/core/Button/index.js'
   import Switch from '$ui/core/Switch/index.js'
-  import Tooltip from '$ui/core/Tooltip/index.js'
   import { useLogoutFlow } from '$lib/flow/logout/index.js'
   import { SANBASE_ORIGIN } from '$lib/utils/links.js'
   import { cn } from '$ui/utils/index.js'
+  import Popover from '$ui/core/Popover/Popover.svelte'
 
   import ProfilePicture from './ProfilePicture.svelte'
   import AccountInfo from './AccountInfo.svelte'
@@ -34,9 +34,9 @@
   }
 </script>
 
-<Tooltip class="z-[100] w-[240px] divide-y overflow-auto p-0 text-fiord column">
-  {#snippet children({ ref })}
-    <ProfilePicture class={className} {ref}></ProfilePicture>
+<Popover class="z-[100] w-[240px] divide-y overflow-auto p-0 text-fiord column" openOnHover>
+  {#snippet children({ props })}
+    <ProfilePicture class={className} {...props}></ProfilePicture>
   {/snippet}
 
   {#snippet content({ close })}
@@ -98,7 +98,7 @@
       {/if}
     </section>
   {/snippet}
-</Tooltip>
+</Popover>
 
 {#snippet sanbaseLink(
   text: string,

--- a/src/lib/ui/app/AccountDropdown/ProfilePicture.svelte
+++ b/src/lib/ui/app/AccountDropdown/ProfilePicture.svelte
@@ -7,11 +7,7 @@
   import { cn } from '$ui/utils/index.js'
   import Picture from '$ui/app/Picture/index.js'
 
-  let {
-    class: className,
-    as,
-    ref,
-  }: Partial<Pick<ComponentProps<typeof Button>, 'as' | 'ref' | 'class'>> = $props()
+  const { class: className, ...rest }: ComponentProps<typeof Button> = $props()
 
   const { customer, currentUser } = useCustomerCtx()
 
@@ -20,8 +16,6 @@
 </script>
 
 <Button
-  {ref}
-  {as}
   variant="plain"
   style="--tw-ring-color:var(--{isBusinessPro ? 'blue' : isPro ? 'orange' : 'casper'})"
   class={cn(
@@ -31,6 +25,7 @@
       : 'bg-athens hover:bg-porcelain data-[state=open]:bg-porcelain',
     className,
   )}
+  {...rest}
 >
   {#if currentUser.$$}
     <Picture class="size-6 text-base md:size-10" src={currentUser.$$.avatarUrl}>

--- a/src/lib/ui/app/Products/index.svelte
+++ b/src/lib/ui/app/Products/index.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-  import type { SS } from 'svelte-runes'
   import type { Snippet } from 'svelte'
 
-  import Tooltip from '$ui/core/Tooltip/index.js'
   import Button from '$ui/core/Button/Button.svelte'
   import { cn } from '$ui/utils/index.js'
+  import Popover from '$ui/core/Popover/Popover.svelte'
 
   import Products from './Products.svelte'
 
@@ -17,7 +16,7 @@
     active?: any
     variant?: 'green' | 'blue'
     closeTimeout?: number
-    children?: Snippet<[{ ref: SS<HTMLElement | null> }]>
+    children?: Snippet<[{ props: Record<string, unknown> }]>
   }
 
   const {
@@ -32,18 +31,19 @@
   }: TProps = $props()
 </script>
 
-<Tooltip
+<Popover
   {isOpened}
-  position="bottom-end"
+  side="bottom"
+  align="end"
   class={cn('dark:bg-white', className)}
   closeDelay={closeTimeout}
+  openOnHover
 >
-  {#snippet children({ ref })}
+  {#snippet children({ props })}
     {#if outerChildren}
-      {@render outerChildren({ ref })}
+      {@render outerChildren({ props })}
     {:else}
       <Button
-        {ref}
         variant="plain"
         icon="products-toggle"
         iconSize={16}
@@ -51,11 +51,12 @@
           'mr-10 fill-waterloo',
           variant === 'green' ? 'hover:fill-green' : 'hover:fill-blue',
         )}
-      ></Button>
+        {...props}
+      />
     {/if}
   {/snippet}
 
   {#snippet content()}
     <Products {active} {variant} {isCompact} class={dropdownClassName} />
   {/snippet}
-</Tooltip>
+</Popover>


### PR DESCRIPTION
## Summary

- Notion ticket: https://app.notion.com/p/santiment/Fix-bugs-on-tablets-July-2026-3a72a82d13618092b124d2f2efb6b0d2?source=copy_link

Replace `Tooltip` with `Popover` in dropdown-like menus. It fixes such menu access on touch devices

`Products` update is breaking current API

<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #460 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #459 
- <kbd>&nbsp;2&nbsp;</kbd> #458 
- <kbd>&nbsp;1&nbsp;</kbd> #457 
<!-- GitButler Footer Boundary Bottom -->