### PR TITLE
fix(tailwind) Disable hover for touch devices

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -155,6 +155,12 @@ export default {
       },
     }),
 
+    // FIXME: Remove after tailwind upgrate to v4
+    // NOTE: Disable hover for devices that don't support it (touch)
+    plugin(function ({ addVariant }) {
+      addVariant('hover', '@media (hover: hover) { &:hover }')
+    }),
+
     plugin(function ({ addUtilities }) {
       addUtilities({
         '.row': {


### PR DESCRIPTION
## Summary

- Notion ticket: https://app.notion.com/p/Fix-Mobile-bugs-July-2026-3a72a82d1361802da5e3f65eb700df36?source=copy_link

Disable `:hover` for devices that don't support hover

