### PR TITLE
fix(pricing) Add padding for all screens to prevent no padding on tablets

### DIFF
--- a/src/lib/ui/app/SubscriptionPlan/PricingSection.svelte
+++ b/src/lib/ui/app/SubscriptionPlan/PricingSection.svelte
@@ -53,7 +53,7 @@
   }
 </script>
 
-<section class={cn('sm:px-5', className)}>
+<section class={cn('px-5', className)}>
   <h1 class="mb-14 max-w-4xl text-start text-3xl font-medium sm:text-center">
     Power your trading decisions with Santiment: tailored crypto analytics for Investors, Traders,
     and Researchers

--- a/src/stories/Design System - App UI/PricingSection/index.svelte
+++ b/src/stories/Design System - App UI/PricingSection/index.svelte
@@ -18,6 +18,6 @@
   })
 </script>
 
-<main class="gap-[120px] px-5 py-16 column sm:gap-[104px] sm:px-0">
+<main class="gap-[120px] py-16 column sm:gap-[104px]">
   <PricingSection {...props}></PricingSection>
 </main>


### PR DESCRIPTION
## Summary

- Notion ticket: https://app.notion.com/p/santiment/Fix-bugs-on-tablets-July-2026-3a72a82d13618092b124d2f2efb6b0d2?source=copy_link

Add horizontal padding to `PricingSection` on all screen sizes to prevent situations with no padding on the page (some tablets)
