### PR TITLE
feat/info-button

### DIFF
--- a/src/lib/ui/app/InfoButton/InfoDialog.svelte
+++ b/src/lib/ui/app/InfoButton/InfoDialog.svelte
@@ -1,0 +1,36 @@
+<script lang="ts" module>
+  import { dialogs$ } from '$lib/ui/core/Dialog/index.js'
+
+  import Component from './InfoDialog.svelte'
+
+  export const showInfoDialog$ = () => dialogs$.new(Component)
+</script>
+
+<script lang="ts">
+  import type { Snippet } from 'svelte'
+
+  import Dialog, { type TDialogProps } from '$lib/ui/core/Dialog/index.js'
+  import Button from '$lib/ui/core/Button/index.js'
+  import { cn } from '$ui/utils/index.js'
+
+  type TProps = {
+    class?: string
+    title: string
+    children: Snippet
+  } & TDialogProps
+
+  const { class: className, title, children, Controller }: TProps = $props()
+</script>
+
+<Dialog class="h-auto">
+  <h2
+    class="flex items-center justify-between border-b bg-athens px-5 py-2 pr-3 text-base text-fiord"
+  >
+    {title}
+    <Button icon="close" iconSize="12" onclick={() => Controller.close()} />
+  </h2>
+
+  <section class={cn('px-5 py-4 text-base', className)}>
+    {@render children()}
+  </section>
+</Dialog>

--- a/src/lib/ui/app/InfoButton/index.svelte
+++ b/src/lib/ui/app/InfoButton/index.svelte
@@ -1,0 +1,60 @@
+<script lang="ts">
+  import type { ComponentProps, Snippet } from 'svelte'
+
+  import { useDeviceCtx } from '$lib/ctx/device/index.svelte.js'
+  import Popover from '$ui/core/Popover/Popover.svelte'
+  import Button from '$ui/core/Button/Button.svelte'
+  import { cn } from '$ui/utils/index.js'
+
+  import { showInfoDialog$ } from './InfoDialog.svelte'
+
+  type TProps = {
+    class?: string
+    title?: string
+    contentClass?: string
+    triggerProps?: Omit<ComponentProps<typeof Button>, 'onclick' | 'class'>
+    children: Snippet
+  }
+
+  const {
+    class: className,
+    contentClass,
+    title = 'Info',
+    triggerProps,
+    children: infoContent,
+  }: TProps = $props()
+
+  const { device } = useDeviceCtx.get()
+  const showInfoDialog = showInfoDialog$()
+
+  let isPopoverOpened = $state(false)
+</script>
+
+{#if device.$.isPhone}
+  {@render trigger({
+    onclick: () => showInfoDialog({ title, class: contentClass, children: infoContent }),
+    ...triggerProps,
+  })}
+{:else}
+  <Popover bind:isOpened={isPopoverOpened} class="p-0" openOnHover>
+    {#snippet children({ props })}
+      {@render trigger({ ...props, ...triggerProps })}
+    {/snippet}
+
+    {#snippet content()}
+      <section class={cn('max-w-60 px-5 py-4 text-sm', contentClass)}>
+        {@render infoContent()}
+      </section>
+    {/snippet}
+  </Popover>
+{/if}
+
+{#snippet trigger(props: ComponentProps<typeof Button>)}
+  <Button
+    size="sm"
+    icon="info"
+    iconSize="12"
+    class={cn(isPopoverOpened && 'bg-[var(--ghost-active-bg)', className)}
+    {...props}
+  />
+{/snippet}

--- a/src/lib/ui/app/InfoButton/index.ts
+++ b/src/lib/ui/app/InfoButton/index.ts
@@ -1,0 +1,1 @@
+export { default } from './index.svelte'

--- a/src/lib/ui/app/SubscriptionPlan/BreakdownTable/Feature.svelte
+++ b/src/lib/ui/app/SubscriptionPlan/BreakdownTable/Feature.svelte
@@ -2,8 +2,7 @@
   import type { TBreakdownFeature } from './breakdown.js'
 
   import Svg from '$ui/core/Svg/index.js'
-  import Tooltip from '$ui/core/Tooltip/index.js'
-  import Button from '$ui/core/Button/index.js'
+  import InfoButton from '$ui/app/InfoButton/index.js'
 
   let {
     plans = [],
@@ -22,15 +21,7 @@
 <div class="td-h txt-left flex items-center gap-1 text-rhino">
   {name}
   {#if description}
-    <Tooltip position="bottom">
-      {#snippet children({ ref })}
-        <Button {ref} icon="info" size="sm" />
-      {/snippet}
-
-      {#snippet content()}
-        <div class="description body-3">{@html description}</div>
-      {/snippet}
-    </Tooltip>
+    <InfoButton>{@html description}</InfoButton>
   {/if}
 </div>
 
@@ -52,16 +43,3 @@
     {/if}
   </div>
 {/each}
-
-<style>
-  .description {
-    padding: 14px 20px;
-    max-width: 252px;
-    color: var(--rhino);
-
-    :global(b) {
-      font-weight: 600;
-      color: var(--black);
-    }
-  }
-</style>

--- a/src/stories/Design System - App UI/InfoButton/index.stories.ts
+++ b/src/stories/Design System - App UI/InfoButton/index.stories.ts
@@ -1,0 +1,16 @@
+import type { Meta, StoryObj } from '@storybook/svelte'
+import component from './index.svelte'
+
+const meta = {
+  component,
+  parameters: {
+    layout: 'fullscreen',
+  },
+} satisfies Meta<component>
+type Story = StoryObj<typeof meta>
+
+export default meta
+
+export const InfoButton: Story = {
+  parameters: {},
+}

--- a/src/stories/Design System - App UI/InfoButton/index.svelte
+++ b/src/stories/Design System - App UI/InfoButton/index.svelte
@@ -1,0 +1,13 @@
+<script>
+  import InfoButton from '$ui/app/InfoButton/index.js'
+</script>
+
+<div class="flex h-screen items-center justify-center gap-4">
+  <div class="flex flex-col items-start gap-2">
+    <h3>Regular info button. Popover on desktop and tablet, dialog on phones</h3>
+
+    <InfoButton>
+      Some <b>entity</b> info
+    </InfoButton>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

- Notion ticket: https://app.notion.com/p/santiment/Fix-bugs-on-tablets-July-2026-3a72a82d13618092b124d2f2efb6b0d2?source=copy_link

Add `InfoButton` component:
Small (by default) Button with `info` icon. On hover/tap opens `Popover` on desktop and tablets and `Dialog` on phones

It's going to replace various custom info tooltips and dialogs in Sanbase. Some of them don't work correctly on touch devices (don't work at all) and phone (open small tooltip instead of dialog)
